### PR TITLE
Metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-- "4"
 - "6"
+- "7"
 script:
 - npm install
 - npm run lint

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ const instance = initialize({
 });
 
 // optional events
-instance.on('error', console.error.bind(console, 'error'));
-instance.on('warn', console.warn.bind(console, 'warn'));
-instance.on('ready', console.warn.bind(console, 'ready'));
+instance.on('error', console.error);
+instance.on('warn', console.warn);
+instance.on('ready', console.log);
 ```
 
 ### 2. Use unleash
@@ -91,6 +91,7 @@ const instance = new Unleash({
 });
 
 instance.on('ready', console.log.bind(console, 'ready'));
-instance.on('error', console.log.bind(console, 'error'))
+// required error handling when using instance directly
+instance.on('error', console.error);
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and poll updates from the unleash-server at regular intervals.
 ```js
 const { initialize } = require('unleash-client');
 const instance = initialize({
-    url: 'http://unleash.herokuapp.com/features'
+    url: 'http://unleash.herokuapp.com'
 });
 
 // optional events
@@ -74,7 +74,7 @@ class ActiveForUserWithEmailStrategy extends Strategy {
 
 ```js
 initialize({
-    url: 'http://unleash.herokuapp.com/features',
+    url: 'http://unleash.herokuapp.com',
     strategies: [new ActiveForUserWithEmailStrategy()]
 });
 ```
@@ -87,7 +87,7 @@ const { Unleash } = require('unleash-client');
 
 
 const instance = new Unleash({
-    url: 'http://unleash.herokuapp.com/features'
+    url: 'http://unleash.herokuapp.com'
 });
 
 instance.on('ready', console.log.bind(console, 'ready'));

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ const instance = initialize({
 instance.on('error', console.error);
 instance.on('warn', console.warn);
 instance.on('ready', console.log);
+
+// metrics hooks
+instance.on('registered', (clientData) => console.log('registered', clientData));
+instance.on('sent', (payload) => console.log('metrics bucket/payload sent', payload));
+instance.on('count', (name, enabled) => console.log(`isEnabled(${name}) returned ${enabled}`));
 ```
 
 ### 2. Use unleash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ and poll updates from the unleash-server at regular intervals.
 ```js
 const { initialize } = require('unleash-client');
 const instance = initialize({
-    url: 'http://unleash.herokuapp.com'
+    url: 'http://unleash.herokuapp.com',
+    appName: 'my-app-name',
+    instanceId: 'my-unique-instance-id',
 });
 
 // optional events
@@ -51,8 +53,12 @@ destroy();
 The initialize method takes the following arguments:
 
 - **url** - the url to fetch toggles from. (required)
+- **appName** - the application name / codebase name
+- **instanceId** - an unique identifier, should/could be somewhat unique
 - **refreshIntervall** - The poll-intervall to check for updates. Defaults to 15s.
 - **strategies** - Custom activation strategies to be used.
+- **disableMetrics** - disable metrics
+
 
 ## Custom strategies
 
@@ -87,6 +93,7 @@ const { Unleash } = require('unleash-client');
 
 
 const instance = new Unleash({
+    appName: 'my-app-name',
     url: 'http://unleash.herokuapp.com'
 });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/Unleash/unleash-client-node",
   "dependencies": {
-    "debug": "^2.2.0",
     "request": "^2.74.0"
   },
   "engines": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -55,6 +55,10 @@ export default class UnleashClient {
             return false;
         }
 
+        if (feature.strategies.length === 0) {
+            return feature.enabled;
+        }
+
         return feature.strategies.length > 0 && feature.strategies
             .some((strategySelector) : boolean => {
                 const strategy: Strategy = this.getStrategy(strategySelector.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { Unleash } from './unleash';
 let instance;
 export function initialize (options: UnleashConfig) {
     instance = new Unleash(options);
+    instance.on('error', () => {});
     return instance;
 };
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -69,7 +69,7 @@ export default class Metrics extends EventEmitter {
 
     stop () {
         clearInterval(this.timer);
-        this.timer = null;
+        delete this.timer;
         this.disabled = true;
     }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -3,7 +3,7 @@ import { ClientResponse } from 'http';
 import { resolve } from 'url';
 import { post, Data } from './request';
 
-interface MetricsOptions {
+export interface MetricsOptions {
     appName : string,
     instanceId : string,
     strategies : string [],
@@ -15,7 +15,7 @@ interface MetricsOptions {
 
 interface Bucket {
     start: Date,
-    stop: Date,
+    stop: Date | null,
     toggles: Object
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -144,7 +144,7 @@ export default class Metrics extends EventEmitter {
                 no: 0,
             };
         }
-        this.bucket.toggles[name][enabled ? 'yes' : 'no'] += 1;
+        this.bucket.toggles[name][enabled ? 'yes' : 'no'] ++;
         return true;
     }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'events';
+import * as request from 'request';
+import { ClientResponse } from 'http';
+import { resolve } from 'url';
+
+interface MetricsOptions {
+    appName : string,
+    instanceId : string,
+    strategies : string [],
+    metricsInterval : number,
+    bucketInterval?: number
+    url : string,
+}
+
+interface Bucket {
+    start: Date,
+    stop: Date,
+    toggles: Object
+}
+
+export default class Metrics extends EventEmitter {
+    private bucket: Bucket;
+    private appName : string;
+    private instanceId : string;
+    private strategies : string [];
+    private metricsInterval: number;
+    private bucketInterval: number;
+    private url : string;
+    private timer : NodeJS.Timer;
+    private started : Date;
+
+    constructor ({
+        appName,
+        instanceId,
+        strategies,
+        metricsInterval,
+        url,
+        } : MetricsOptions
+    ) {
+        super();
+        this.metricsInterval = metricsInterval;
+        this.appName = appName;
+        this.instanceId = instanceId;
+        this.strategies = strategies;
+        this.url = url;
+        this.started = new Date();
+        this.resetBucket();
+        this.startTimer();
+    }
+
+    private startTimer () {
+        if (this.metricsInterval) {
+            this.timer = setTimeout(() => {
+                this.sendMetrics();
+            }, this.metricsInterval);
+            this.timer.unref();
+        }
+    }
+
+    sendMetrics () {
+        const url = resolve(this.url, '/metrics');
+        request.post({
+             url,
+             json: this.getPayload(),
+        }, (err, res: ClientResponse, body) => {
+            this.startTimer();
+            if (err) {
+                this.emit('error', err);
+                return;
+            }
+
+            if (res.statusCode === 404) {
+                this.emit('warn', `${url} returning 404, stopping metrics`);
+                clearTimeout(this.timer);
+                return;
+            }
+
+            if (res.statusCode !== 200) {
+                this.emit('warn', `${url} returning ${res.statusCode}`);
+                return;
+            }
+        });
+    }
+
+
+    count (name: string, enabled: boolean) : void {
+        if (!this.bucket.toggles[name]) {
+            this.bucket.toggles[name] = {
+                yes: 0,
+                no: 0,
+            };
+        }
+        this.bucket.toggles[name][enabled ? 'yes' : 'no'] += 1;
+    }
+
+    private resetBucket () {
+        const bucket : Bucket = {
+            start: new Date(),
+            stop: null,
+            toggles: {}
+        };
+        this.bucket = bucket;
+    }
+
+    private closeBucket () {
+        this.bucket.stop = new Date();
+    }
+
+    private getPayload () {
+        this.closeBucket();
+        const payload = this.toJSON();
+        this.resetBucket();
+        return payload;
+    }
+
+    toJSON () : string {
+        return JSON.stringify({
+            metricsInterval: this.metricsInterval,
+            clientInitTime: this.started,
+            appName: this.appName,
+            instanceId: this.instanceId,
+            strategies: this.strategies,
+            bucket: this.bucket,
+        });
+    }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -144,7 +144,8 @@ export default class Metrics extends EventEmitter {
                 no: 0,
             };
         }
-        this.bucket.toggles[name][enabled ? 'yes' : 'no'] ++;
+        this.bucket.toggles[name][enabled ? 'yes' : 'no']++;
+        this.emit('count', name, enabled);
         return true;
     }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -115,8 +115,8 @@ export default class Metrics extends EventEmitter {
 
     toJSON () : string {
         return JSON.stringify({
-            metricsInterval: this.metricsInterval,
-            clientInitTime: this.started,
+            interval: this.metricsInterval,
+            started: this.started,
             appName: this.appName,
             instanceId: this.instanceId,
             strategies: this.strategies,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import { toNewFormat, pickData } from './data-formatter';
 import { Storage } from './storage';
 import { FeatureInterface } from './feature';
+import { resolve } from 'url';
 
 export default class Repository extends EventEmitter implements EventEmitter {
     private timer;
@@ -48,8 +49,9 @@ export default class Repository extends EventEmitter implements EventEmitter {
     }
 
     fetch () {
+        const url = resolve(this.url, '/features');
         request({
-            url: this.url,
+            url,
             headers: { 'If-None-Match': this.etag },
         }, (error, res, body: string) => {
             // start timer for next fetch

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,10 +1,10 @@
 import * as request from 'request';
 
-interface RequestOptions {
+export interface RequestOptions {
     url: string,
 }
 
-interface GetRequestOptions extends RequestOptions {
+export interface GetRequestOptions extends RequestOptions {
     etag?: string,
     requestId?: string,
 }
@@ -13,17 +13,15 @@ export interface Data {
     [key: string]: any,
 }
 
-interface PostRequestOptions extends RequestOptions {
+export interface PostRequestOptions extends RequestOptions {
     json?: Data,
 }
 
-// TODO headers
-
-export const post = (options : PostRequestOptions, cb: Function) => {
+export const post = (options : PostRequestOptions, cb) => {
     return request.post(options, cb);
 };
 
-export const get = ({ url, etag, requestId } : GetRequestOptions, cb: Function) => {
+export const get = ({ url, etag, requestId } : GetRequestOptions, cb) => {
     const options = {
         url,
         requestId,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,38 @@
+import * as request from 'request';
+
+interface RequestOptions {
+    url: string,
+}
+
+interface GetRequestOptions extends RequestOptions {
+    etag?: string,
+    requestId?: string,
+}
+
+export interface Data {
+    [key: string]: any,
+}
+
+interface PostRequestOptions extends RequestOptions {
+    json?: Data,
+}
+
+// TODO headers
+
+export const post = (options : PostRequestOptions, cb: Function) => {
+    return request.post(options, cb);
+};
+
+export const get = ({ url, etag, requestId } : GetRequestOptions, cb: Function) => {
+    const options = {
+        url,
+        requestId,
+        headers: {
+            'UNLEASH-ID': requestId,
+        },
+    };
+    if (etag) {
+        options.headers['If-None-Match'] = etag;
+    }
+    return request.get(options, cb);
+};

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -50,21 +50,14 @@ export class Unleash extends EventEmitter {
             instanceId = `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
         }
 
-        this.repository = new Repository(backupPath, url, refreshInterval);
+        const requestId: string = `${appName}:${instanceId}`;
+        this.repository = new Repository(backupPath, url, requestId, refreshInterval);
 
         strategies = [new Strategy('default', true)].concat(strategies);
 
         this.repository.on('ready', () => {
             this.client = new Client(this.repository, strategies, errorHandler);
             this.emit('ready');
-        });
-
-        this.metrics = new Metrics({
-            appName,
-            instanceId,
-            strategies: strategies.map((strategy: Strategy) => strategy.name),
-            metricsInterval,
-            url
         });
 
         this.repository.on('error', (err) => {
@@ -76,6 +69,14 @@ export class Unleash extends EventEmitter {
             this.emit('warn', msg);
         });
 
+        this.metrics = new Metrics({
+            appName,
+            instanceId,
+            strategies: strategies.map((strategy: Strategy) => strategy.name),
+            metricsInterval,
+            url
+        });
+
         this.metrics.on('error', (err) => {
             err.message = `Unleash Metrics error: ${err.message}`;
             this.emit('error', err);
@@ -84,6 +85,8 @@ export class Unleash extends EventEmitter {
         this.metrics.on('warn', (msg) => {
             this.emit('warn', msg);
         });
+
+
     }
 
     destroy () {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 const BACKUP_PATH: string = tmpdir();
 
 export interface UnleashConfig {
-    appName?: string,
+    appName: string,
     instanceId?: string,
     url: string;
     refreshInterval?: number;
@@ -87,6 +87,18 @@ export class Unleash extends EventEmitter {
 
         this.metrics.on('warn', (msg) => {
             this.emit('warn', msg);
+        });
+
+        this.metrics.on('count', (name, enabled) => {
+            this.emit('count', name, enabled);
+        });
+
+        this.metrics.on('sent', (payload) => {
+            this.emit('sent', payload);
+        });
+
+        this.metrics.on('registered', (payload) => {
+            this.emit('registered', payload);
         });
     }
 

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -47,7 +47,7 @@ export class Unleash extends EventEmitter {
         }
 
         if (!instanceId) {
-            instanceId = `${appName}-${Math.round(Math.random() * 1000000)}-${process.pid}`;
+            instanceId = `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
         }
 
         this.repository = new Repository(backupPath, url, refreshInterval);

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -85,8 +85,6 @@ export class Unleash extends EventEmitter {
         this.metrics.on('warn', (msg) => {
             this.emit('warn', msg);
         });
-
-
     }
 
     destroy () {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -31,7 +31,7 @@ export class Unleash extends EventEmitter {
         instanceId,
         url,
         refreshInterval = 15 * 1000,
-        metricsInterval = 15 * 1000,
+        metricsInterval = 60 * 1000,
         backupPath = BACKUP_PATH,
         strategies = [],
         errorHandler = () => {}

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -15,6 +15,7 @@ export interface UnleashConfig {
     url: string;
     refreshInterval?: number;
     metricsInterval?: number,
+    disableMetrics?: boolean,
     backupPath?: string;
     strategies: Strategy[];
     errorHandler?: (err: any) => any;
@@ -32,6 +33,7 @@ export class Unleash extends EventEmitter {
         url,
         refreshInterval = 15 * 1000,
         metricsInterval = 60 * 1000,
+        disableMetrics = false,
         backupPath = BACKUP_PATH,
         strategies = [],
         errorHandler = () => {}
@@ -70,6 +72,7 @@ export class Unleash extends EventEmitter {
         });
 
         this.metrics = new Metrics({
+            disableMetrics,
             appName,
             instanceId,
             strategies: strategies.map((strategy: Strategy) => strategy.name),

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -92,6 +92,7 @@ export class Unleash extends EventEmitter {
 
     destroy () {
         this.repository.stop();
+        this.metrics.stop();
         this.client = undefined;
     }
 

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -19,18 +19,22 @@ const defaultToggles = [
         strategy: 'default',
     },
 ];
+
+let counter = 0;
 function mockNetwork (toggles = defaultToggles) {
-    nock('http://unleash.app')
+    const url = `http://unleash-${counter++}.app`;
+    nock(url)
         .get('/features')
         .reply(200,  { features: toggles });
+    return url;
 }
 
 test('should be able to call api', (t) => {
-    mockNetwork();
+    const url = mockNetwork();
     initialize({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/features',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             throw e;
@@ -41,11 +45,11 @@ test('should be able to call api', (t) => {
 });
 
 test.cb('should be able to call isEnabled eventually', (t) => {
-    mockNetwork();
+    const url = mockNetwork();
     const instance = initialize({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/features',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             throw e;

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -28,6 +28,8 @@ function mockNetwork (toggles = defaultToggles) {
 test('should be able to call api', (t) => {
     mockNetwork();
     initialize({
+        appName: 'foo',
+        metricsInterval: 0,
         url: 'http://unleash.app/features',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
@@ -41,6 +43,8 @@ test('should be able to call api', (t) => {
 test.cb('should be able to call isEnabled eventually', (t) => {
     mockNetwork();
     const instance = initialize({
+        appName: 'foo',
+        metricsInterval: 0,
         url: 'http://unleash.app/features',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {

--- a/test/metrics.network.test.js
+++ b/test/metrics.network.test.js
@@ -1,0 +1,40 @@
+import test from 'ava';
+import Metrics from '../lib/metrics';
+import nock from 'nock';
+
+nock.disableNetConnect();
+
+
+
+test.cb('registerInstance should emit error when request error', (t) => {
+    const url = 'http://metrics1.app/';
+
+    const metrics = new Metrics({
+        url,
+    });
+    metrics.on('error', (e) => {
+        t.truthy(e);
+        t.end();
+    });
+
+    t.true(metrics.registerInstance());
+});
+
+
+
+test.cb('sendMetrics should emit error when request error', (t) => {
+    const url = 'http://metrics2.app/';
+
+    const metrics = new Metrics({
+        url,
+    });
+    metrics.on('error', (e) => {
+        t.truthy(e);
+        t.end();
+    });
+
+    metrics.count('x', true);
+
+    t.true(metrics.sendMetrics());
+});
+

--- a/test/metrics.network.test.js
+++ b/test/metrics.network.test.js
@@ -2,9 +2,8 @@ import test from 'ava';
 import Metrics from '../lib/metrics';
 import nock from 'nock';
 
-nock.disableNetConnect();
-
-
+test.before(() => nock.disableNetConnect());
+test.after(() => nock.enableNetConnect());
 
 test.cb('registerInstance should emit error when request error', (t) => {
     const url = 'http://metrics1.app/';

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,197 @@
+import test from 'ava';
+import Metrics from '../lib/metrics';
+import nock from 'nock';
+
+let counter = 1;
+const getUrl = () => `http://test${counter++}.app/`;
+const metricsUrl = '/client/metrics';
+const nockMetrics = (url, code = 200) => nock(url)
+        .post(metricsUrl)
+        .reply(code, '');
+const registerUrl = '/client/register';
+const nockRegister = (url, code = 200) => nock(url)
+        .post(registerUrl)
+        .reply(code, '');
+
+
+test('should be disabled by flag disableMetrics', (t) => {
+    const metrics = new Metrics({ disableMetrics: true });
+    metrics.count('foo', true);
+
+    t.true(Object.keys(metrics.bucket.toggles).length === 0);
+});
+
+test('registerInstance, sendMetrics, startTimer and count should respect disabled', (t) => {
+    const url = getUrl();
+    const metrics = new Metrics({
+        url,
+        disableMetrics: true,
+    });
+    t.true(!metrics.startTimer());
+    t.true(!metrics.registerInstance());
+    t.true(!metrics.count());
+    t.true(!metrics.sendMetrics());
+});
+
+test('should not start fetch/register when metricsInterval is 0', (t) => {
+    const url = getUrl();
+    const metrics = new Metrics({
+        url,
+        metricsInterval: 0,
+    });
+
+    t.true(metrics.timer === undefined);
+});
+
+test.cb('should sendMetrics and register when metricsInterval is a positive number', (t) => {
+    const url = getUrl();
+    t.plan(2);
+    const metricsEP = nockMetrics(url);
+    const regEP = nockRegister(url);
+
+    const metrics = new Metrics({
+        url,
+        metricsInterval: 50,
+    });
+
+    metrics.count('toggle-x', true);
+    metrics.count('toggle-x', false);
+    metrics.count('toggle-y', true);
+
+    metrics.on('registered', () => {
+        t.true(regEP.isDone());
+    });
+
+    metrics.on('sent', () => {
+        t.true(metricsEP.isDone());
+        t.end();
+        metrics.stop();
+    });
+});
+
+
+test.cb('registerInstance should warn when non 200 statusCode', (t) => {
+    const url = getUrl();
+    const regEP = nockRegister(url, 500);
+
+    const metrics = new Metrics({
+        url,
+    });
+    metrics.on('error', (e) => {
+        t.falsy(e);
+    });
+
+    metrics.on('warn', (e) => {
+        t.true(regEP.isDone());
+        t.truthy(e);
+        t.end();
+    });
+
+    t.true(metrics.registerInstance());
+});
+
+test.cb('sendMetrics should stop/disable metrics if endpoint returns 404', (t) => {
+    const url = getUrl();
+    const metEP = nockMetrics(url, 404);
+    const metrics = new Metrics({
+        url,
+    });
+
+    metrics.on('warn', () => {
+        metrics.stop();
+        t.true(metEP.isDone());
+        t.true(metrics.disabled);
+        t.end();
+    });
+
+    metrics.count('x-y-z', true);
+
+    metrics.sendMetrics();
+
+    t.false(metrics.disabled);
+});
+
+test.cb('sendMetrics should emit warn on non 200 statusCode', (t) => {
+    const url = getUrl();
+    const metEP = nockMetrics(url, 500);
+
+    const metrics = new Metrics({
+        url,
+    });
+
+    metrics.on('warn', () => {
+        t.true(metEP.isDone());
+        t.end();
+    });
+
+    metrics.count('x-y-z', true);
+
+    metrics.sendMetrics();
+});
+
+test.cb('sendMetrics should not send empty buckets', (t) => {
+    const url = getUrl();
+    const metEP = nockMetrics(url, 200);
+
+    const metrics = new Metrics({
+        url,
+    });
+
+    t.true(metrics.sendMetrics());
+
+    setTimeout(() => {
+        t.false(metEP.isDone());
+        t.end();
+    }, 10);
+});
+
+
+test('count should increment yes and no counters', (t) => {
+    const url = getUrl();
+    const metrics = new Metrics({
+        url,
+    });
+
+    const name = `name-${Math.round(Math.random() * 1000)}`;
+
+    t.falsy(metrics.bucket.toggles[name]);
+
+    metrics.count(name, true);
+
+    const toggleCount = metrics.bucket.toggles[name];
+    t.truthy(toggleCount);
+    t.true(toggleCount.yes === 1);
+    t.true(toggleCount.no === 0);
+
+    metrics.count(name, true);
+    metrics.count(name, true);
+    metrics.count(name, false);
+    metrics.count(name, false);
+    metrics.count(name, false);
+    metrics.count(name, false);
+
+    t.true(toggleCount.yes === 3);
+    t.true(toggleCount.no === 4);
+});
+
+test('getClientData should return a object', (t) => {
+    const url = getUrl();
+    const metrics = new Metrics({
+        url,
+    });
+
+    const result = metrics.getClientData();
+    t.true(typeof result === 'object');
+});
+
+test('getMetricsData should return a bucket', (t) => {
+    const url = getUrl();
+    const metrics = new Metrics({
+        url,
+    });
+
+    const result = metrics.getMetricsData();
+    t.true(typeof result === 'object');
+    t.true(typeof result.bucket === 'object');
+});
+

--- a/test/repository.test.js
+++ b/test/repository.test.js
@@ -39,7 +39,7 @@ test.cb('should fetch from endpoint', (t) => {
     };
 
     setup(url, [feature]);
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}`, 'foo:bar', 0, MockStorage);
 
     repo.once('data', () => {
         const savedFeature = repo.storage.data[feature.name];
@@ -55,7 +55,7 @@ test.cb('should fetch from endpoint', (t) => {
 test('should poll for changes', () => new Promise((resolve) => {
     const url = 'http://unleash-test-2.app';
     setup(url, []);
-    const repo = new Repository('foo', `${url}/features`, 100, MockStorage);
+    const repo = new Repository('foo', `${url}`, 'foo:bar', 100, MockStorage);
 
     let assertCount = 5;
     repo.on('data', () => {
@@ -71,7 +71,7 @@ test('should poll for changes', () => new Promise((resolve) => {
 test('should store etag', (t) => new Promise((resolve) => {
     const url = 'http://unleash-test-3.app';
     setup(url, [], { Etag: '12345' });
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}`, 'foo:bar', 0, MockStorage);
 
     repo.once('data', () => {
         t.true(repo.etag === '12345');
@@ -88,7 +88,7 @@ test.cb('should request with etag', (t) => {
         .get('/features')
         .reply(200,  { features: [] }, { Etag: '12345-2' });
 
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}/features`, 'foo:bar', 0, MockStorage);
 
     repo.etag = '12345-1';
 
@@ -105,7 +105,7 @@ test.cb('should handle 404 request error and emit error event', (t) => {
         .get('/features')
         .reply(404, 'asd');
 
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}/features`, 'foo:bar', 0, MockStorage);
 
     repo.on('error', (err) => {
         t.truthy(err);
@@ -120,7 +120,7 @@ test('should handle 304 as silent ok', () => new Promise((resolve, reject) => {
         .get('/features')
         .reply(304, '');
 
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}/features`, 'foo:bar', 0, MockStorage);
     repo.on('error', reject);
     repo.on('data', reject);
     process.nextTick(resolve);
@@ -131,7 +131,7 @@ test('should handle invalid JSON response', (t) => new Promise((resolve, reject)
     nock(url).persist()
         .get('/features')
         .reply(200, '{"Invalid payload');
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}/features`, 'foo:bar', 0, MockStorage);
     repo.on('error', (err) => {
         t.truthy(err);
         t.true(err.message.indexOf('Unexpected token') > -1);
@@ -148,7 +148,7 @@ test.cb('should emit errors on invalid features', (t) => {
         enabled: null,
         strategies: false,
     }]);
-    const repo = new Repository('foo', `${url}/features`, 0, MockStorage);
+    const repo = new Repository('foo', `${url}/features`, 'foo:bar', 0, MockStorage);
 
     repo.once('error', (err) => {
         t.truthy(err);

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,3 +1,0 @@
-import test from 'ava';
-
-test.todo('request');

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,0 +1,3 @@
+import test from 'ava';
+
+test.todo('request');

--- a/test/unleash.network.test.js
+++ b/test/unleash.network.test.js
@@ -12,28 +12,24 @@ test.cb('should emit network errors', (t) => {
     const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
     const unleash = new Unleash({
         appName: 'network',
-        url: 'http://error.github.io',
-        refreshInterval: 10000,
-        metricsInterval: 80,
+        url: 'http://blocked.app',
+        refreshInterval: 20000,
+        metricsInterval: 20000,
         disableMetrics: false,
         backupPath,
     });
 
-    unleash.isEnabled('some-toggle');
-
     unleash.on('error', (e) => {
         t.truthy(e);
-        console.log(e.message);
     });
 
-    unleash.on('warn', (e) => {
-        t.falsy(e);
-    });
+    unleash.isEnabled('some-toggle');
+    unleash.metrics.sendMetrics();
 
-    return setTimeout(() => {
+    setTimeout(() => {
         unleash.destroy();
         process.nextTick(() => {
             t.end();
         });
-    }, 100);
+    }, 0);
 });

--- a/test/unleash.network.test.js
+++ b/test/unleash.network.test.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import nock from 'nock';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Unleash } from '../lib/unleash';
+
+test.before(() => nock.disableNetConnect());
+test.after(() => nock.enableNetConnect());
+
+test.cb('should emit network errors', (t) => {
+    t.plan(3);
+    const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
+    const unleash = new Unleash({
+        appName: 'network',
+        url: 'http://error.github.io',
+        refreshInterval: 10000,
+        metricsInterval: 80,
+        disableMetrics: false,
+        backupPath,
+    });
+
+    unleash.isEnabled('some-toggle');
+
+    unleash.on('error', (e) => {
+        t.truthy(e);
+        console.log(e.message);
+    });
+
+    unleash.on('warn', (e) => {
+        t.falsy(e);
+    });
+
+    return setTimeout(() => {
+        unleash.destroy();
+        process.nextTick(() => {
+            t.end();
+        });
+    }, 100);
+});

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -35,7 +35,9 @@ test.cb('repository should surface error when invalid basePAth', (t) => {
     mockNetwork();
     const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
     const instance = new Unleash({
-        url: 'http://unleash.app/features',
+        appName: 'foo',
+        metricsInterval: 0,
+        url: 'http://unleash.app/',
         backupPath,
         errorHandler (e) {
             throw e;
@@ -53,7 +55,9 @@ test.cb('repository should surface error when invalid basePAth', (t) => {
 test('should allow request even before unleash is initialized', (t) => {
     mockNetwork();
     const instance = new Unleash({
-        url: 'http://unleash.app/features',
+        appName: 'foo',
+        metricsInterval: 0,
+        url: 'http://unleash.app/',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             throw e;
@@ -66,7 +70,9 @@ test('should allow request even before unleash is initialized', (t) => {
 test('should consider known feature-toggle as active', (t) => new Promise((resolve, reject) => {
     mockNetwork();
     const instance = new Unleash({
-        url: 'http://unleash.app/features',
+        appName: 'foo',
+        metricsInterval: 0,
+        url: 'http://unleash.app/',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);
@@ -83,7 +89,9 @@ test('should consider known feature-toggle as active', (t) => new Promise((resol
 test('should consider unknown feature-toggle as disabled', (t) => new Promise((resolve, reject) => {
     mockNetwork();
     const instance = new Unleash({
-        url: 'http://unleash.app/features',
+        appName: 'foo',
+        metricsInterval: 0,
+        url: 'http://unleash.app/',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);
@@ -101,7 +109,9 @@ test('should consider unknown feature-toggle as disabled', (t) => new Promise((r
 test('should return fallback value until online', (t) => new Promise((resolve, reject) => {
     mockNetwork();
     const instance = new Unleash({
-        url: 'http://unleash.app/features',
+        appName: 'foo',
+        metricsInterval: 0,
+        url: 'http://unleash.app/',
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -6,6 +6,9 @@ import mkdirp from 'mkdirp';
 
 import { Unleash } from '../lib/unleash';
 
+let counter = 1;
+const getUrl = () => `http://test2${counter++}.app/`;
+
 function getRandomBackupPath () {
     const path = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
     mkdirp.sync(path);
@@ -19,45 +22,101 @@ const defaultToggles = [
         strategy: 'default',
     },
 ];
-function mockNetwork (toggles = defaultToggles) {
-    nock('http://unleash.app')
-        // .persist()
+function mockNetwork (toggles = defaultToggles, url = getUrl()) {
+    nock(url)
         .get('/features')
         .reply(200,  { features: toggles });
+    return url;
 }
 
 test('should error when missing url', (t) => {
     t.throws(() => new Unleash({}));
     t.throws(() => new Unleash({ url: false }));
+    t.throws(() => new Unleash({ url: 'http://unleash.github.io', appName: false }));
 });
 
-test.cb('repository should surface error when invalid basePAth', (t) => {
-    mockNetwork();
+test('should re-emit error from repository, storage and metrics', (t) => {
+    const url = mockNetwork([]);;
+
+    const instance = new Unleash({
+        appName: 'foo',
+        refreshInterval: 0,
+        metricsInterval: 0,
+        disableMetrics: true,
+        url,
+        errorHandler (e) {
+            throw e;
+        },
+    });
+
+    t.plan(3);
+    instance.on('error', (e) => {
+        t.truthy(e);
+    });
+    instance.repository.emit('error', new Error());
+    instance.repository.storage.emit('error', new Error());
+    instance.metrics.emit('error', new Error());
+
+    instance.destroy();
+});
+
+
+test('should re-emit warn from repository and metrics', (t) => {
+    const url = mockNetwork();
+    const instance = new Unleash({
+        appName: 'foo',
+        refreshInterval: 0,
+        metricsInterval: 0,
+        disableMetrics: true,
+        url,
+        errorHandler (e) {
+            throw e;
+        },
+    });
+
+    t.plan(2);
+    instance.on('warn', (e) => t.truthy(e));
+    instance.repository.emit('warn', new Error());
+    instance.metrics.emit('warn', new Error());
+
+    instance.destroy();
+});
+
+test.cb('repository should surface error when invalid basePath', (t) => {
+    const url = 'http://unleash-surface.app/';
+    nock(url)
+        .get('/features')
+        .delay(100)
+        .reply(200,  { features: [] });
     const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
     const instance = new Unleash({
         appName: 'foo',
-        metricsInterval: 0,
-        url: 'http://unleash.app/',
+        disableMetrics: true,
+        refreshInterval: 0,
+        url,
         backupPath,
         errorHandler (e) {
             throw e;
         },
     });
 
-    instance.on('error', (err) => {
+    instance.once('error', (err) => {
         t.truthy(err);
         t.true(err.code === 'ENOENT');
+
+        instance.destroy();
+
         t.end();
     });
 });
 
 
 test('should allow request even before unleash is initialized', (t) => {
-    mockNetwork();
+    const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             throw e;
@@ -68,11 +127,11 @@ test('should allow request even before unleash is initialized', (t) => {
 });
 
 test('should consider known feature-toggle as active', (t) => new Promise((resolve, reject) => {
-    mockNetwork();
+    const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);
@@ -87,11 +146,11 @@ test('should consider known feature-toggle as active', (t) => new Promise((resol
 }));
 
 test('should consider unknown feature-toggle as disabled', (t) => new Promise((resolve, reject) => {
-    mockNetwork();
+    const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);
@@ -107,11 +166,11 @@ test('should consider unknown feature-toggle as disabled', (t) => new Promise((r
 
 
 test('should return fallback value until online', (t) => new Promise((resolve, reject) => {
-    mockNetwork();
+    const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
         metricsInterval: 0,
-        url: 'http://unleash.app/',
+        url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
             reject(e);

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -61,7 +61,7 @@ test('should re-emit error from repository, storage and metrics', (t) => {
 });
 
 
-test('should re-emit warn from repository and metrics', (t) => {
+test('should re-emit events from repository and metrics', (t) => {
     const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
@@ -73,10 +73,17 @@ test('should re-emit warn from repository and metrics', (t) => {
         },
     });
 
-    t.plan(2);
+    t.plan(5);
     instance.on('warn', (e) => t.truthy(e));
-    instance.repository.emit('warn', new Error());
-    instance.metrics.emit('warn', new Error());
+    instance.on('sent', (e) => t.truthy(e));
+    instance.on('registered', (e) => t.truthy(e));
+    instance.on('count', (e) => t.truthy(e));
+
+    instance.repository.emit('warn', true);
+    instance.metrics.emit('warn', true);
+    instance.metrics.emit('sent', true);
+    instance.metrics.emit('registered', true);
+    instance.metrics.emit('count', true);
 
     instance.destroy();
 });

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -66,7 +66,6 @@ test('should re-emit warn from repository and metrics', (t) => {
     const instance = new Unleash({
         appName: 'foo',
         refreshInterval: 0,
-        metricsInterval: 0,
         disableMetrics: true,
         url,
         errorHandler (e) {
@@ -115,7 +114,7 @@ test('should allow request even before unleash is initialized', (t) => {
     const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
-        metricsInterval: 0,
+        disableMetrics: true,
         url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
@@ -130,7 +129,7 @@ test('should consider known feature-toggle as active', (t) => new Promise((resol
     const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
-        metricsInterval: 0,
+        disableMetrics: true,
         url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
@@ -149,7 +148,7 @@ test('should consider unknown feature-toggle as disabled', (t) => new Promise((r
     const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
-        metricsInterval: 0,
+        disableMetrics: true,
         url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {
@@ -169,7 +168,7 @@ test('should return fallback value until online', (t) => new Promise((resolve, r
     const url = mockNetwork();
     const instance = new Unleash({
         appName: 'foo',
-        metricsInterval: 0,
+        disableMetrics: true,
         url,
         backupPath: getRandomBackupPath(),
         errorHandler (e) {


### PR DESCRIPTION
* Breaking: requires `appName` to be provided
* register client with strategynames at /client/register on startup
* report 60 seconds buckets of metrics to /client/metrics on unleash server
* exposing metric events

cc @ivarconr @SimenB 