### PR TITLE
Use minimum 2.79 of request

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Unleash/unleash-client-node",
   "dependencies": {
-    "request": "^2.74.0"
+    "request": "^2.79.0"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
It changed from deprecated node-uuid to uuid