### PR TITLE
adding IP range support to remoteAddress

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/Unleash/unleash-client-node",
   "dependencies": {
+    "ip": "^1.1.5",
     "murmurhash3js": "^3.0.1",
     "pkginfo": "^0.4.1",
     "request": "^2.79.0"

--- a/src/strategy/remote-addresss-strategy.ts
+++ b/src/strategy/remote-addresss-strategy.ts
@@ -12,14 +12,14 @@ export class RemoteAddressStrategy extends Strategy {
             return false;
         }
         for (const range of parameters.IPs.split(/\s*,\s*/)) {
-            if (!ip.isV6Format(range)) {
+            if (range === context.remoteAddress) {
+                return true;
+            } else if (!ip.isV6Format(range)) {
                 if (ip.cidrSubnet(range).contains(context.remoteAddress)) {
                     return true;
                 }
             }
-            if (range === context.remoteAddress) {
-                return true;
-            }
+            
         }
         return false;
     }

--- a/src/strategy/remote-addresss-strategy.ts
+++ b/src/strategy/remote-addresss-strategy.ts
@@ -1,5 +1,6 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
+const ip = require('ip');
 
 export class RemoteAddressStrategy extends Strategy {
     constructor() {
@@ -10,7 +11,16 @@ export class RemoteAddressStrategy extends Strategy {
         if (!parameters.IPs) {
             return false;
         }
-        const ipList = parameters.IPs.split(/\s*,\s*/);
-        return ipList.includes(context.remoteAddress);
+        for (const range of parameters.IPs.split(/\s*,\s*/)) {
+            if (!ip.isV6Format(range)) {
+                if (ip.cidrSubnet(range).contains(context.remoteAddress)) {
+                    return true;
+                }
+            }
+            if (range === context.remoteAddress) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/test/strategy/remote-address-strategy.test.js
+++ b/test/strategy/remote-address-strategy.test.js
@@ -34,3 +34,9 @@ test('RemoteAddressStrategy should be enabled for ip in list', t => {
     const context = { remoteAddress: '127.0.1.2' };
     t.true(strategy.isEnabled(params, context));
 });
+test('RemoteAddressStrategy should be enabled for ip inside range in a list', t => {
+    const strategy = new RemoteAddressStrategy();
+    const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3, 160.33.0.0/16' };
+    const context = { remoteAddress: '160.33.0.33' };
+    t.true(strategy.isEnabled(params, context));
+});


### PR DESCRIPTION
Adding a gazilion IPs manually is somewhat of a pain, therefor adding support for IPv4 ranges would really make things easier. 
This PR uses the ip module to validate the ranges. I have not updated the docs on this as I wasn't sure if that should go into the PR.