### PR TITLE
RemoteAddressStrategy should ignore invalid IPs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.0 (unreleased)
 
 * Swhich hashing to MurmurHash (https://github.com/Unleash/unleash/issues/247)
+* Bugfix RemoteAddressStrategy (https://github.com/Unleash/unleash-client-node/issues/65)
 
 ## 2.3.1
 

--- a/src/strategy/remote-addresss-strategy.ts
+++ b/src/strategy/remote-addresss-strategy.ts
@@ -12,12 +12,16 @@ export class RemoteAddressStrategy extends Strategy {
             return false;
         }
         for (const range of parameters.IPs.split(/\s*,\s*/)) {
-            if (range === context.remoteAddress) {
-                return true;
-            } else if (!ip.isV6Format(range)) {
-                if (ip.cidrSubnet(range).contains(context.remoteAddress)) {
+            try {
+                if (range === context.remoteAddress) {
                     return true;
+                } else if (!ip.isV6Format(range)) {
+                    if (ip.cidrSubnet(range).contains(context.remoteAddress)) {
+                        return true;
+                    }
                 }
+            } catch (e) {
+                continue;
             }
         }
         return false;

--- a/test/strategy/remote-address-strategy.test.js
+++ b/test/strategy/remote-address-strategy.test.js
@@ -34,9 +34,24 @@ test('RemoteAddressStrategy should be enabled for ip in list', t => {
     const context = { remoteAddress: '127.0.1.2' };
     t.true(strategy.isEnabled(params, context));
 });
+
 test('RemoteAddressStrategy should be enabled for ip inside range in a list', t => {
     const strategy = new RemoteAddressStrategy();
     const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3, 160.33.0.0/16' };
     const context = { remoteAddress: '160.33.0.33' };
+    t.true(strategy.isEnabled(params, context));
+});
+
+test('RemoteAddressStrategy should handle invalid IPs', t => {
+    const strategy = new RemoteAddressStrategy();
+    const params = { IPs: '127.invalid' };
+    const context = { remoteAddress: '127.0.0.1' };
+    t.false(strategy.isEnabled(params, context));
+});
+
+test('RemoteAddressStrategy should ignore invalid IPs', t => {
+    const strategy = new RemoteAddressStrategy();
+    const params = { IPs: '127.0.0.2, 127.invalid, 127.0.0.1' };
+    const context = { remoteAddress: '127.0.0.1' };
     t.true(strategy.isEnabled(params, context));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,9 +50,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^8.0.4":
+"@types/node@*":
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
+
+"@types/node@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
 "@types/request@^2.0.8":
   version "2.0.8"


### PR DESCRIPTION
Today the strategy ends up throwing, making the
whole isEnable call throw if the user has specified
an invalid IP.

It would be better to just ignore that invalid IP
and continue to check the other IPs in the list.

closes #38