### PR TITLE
Build on prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix  && prettier --write '{src,examples}/**/*.ts'",
     "build": "tsc src/*.ts src/**/*.ts -d --strictNullChecks --sourceMap --outdir ./lib --lib ES6,ES5",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "NODE_ENV=test ava test",
     "coverage": "nyc --check-coverage=true npm test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
#73 fails to do the work for npm@^4.0.0 See [here](https://docs.npmjs.com/misc/scripts#deprecation-note).

```
$ npm -v
5.6.0
$ node -v
v6.9.5
```