### PR TITLE
Make sure proper npm is running

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "request": "^2.79.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=6",
+    "npm": ">=4.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
According to [this](https://docs.npmjs.com/misc/scripts#deprecation-note) we should make sure users are using the right version of npm. If they don't use a minimum required version a build will not happen.