### PR TITLE
Make strategies optional in UnleashConfig

### DIFF
--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -22,7 +22,7 @@ export interface UnleashConfig {
     metricsInterval?: number;
     disableMetrics?: boolean;
     backupPath?: string;
-    strategies: Strategy[];
+    strategies?: Strategy[];
     customHeaders?: CustomHeaders;
 }
 


### PR DESCRIPTION
Default value for `strategies` is `[]` in the constructor so we can omit this key when we just want to use default strategies