### PR TITLE
Provide Browser support - #unleash in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # typescript lives in src, output in lib
 lib/
 .vscode
+
+.idea
+**/*.iml

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,6 +861,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bfs-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bfs-path/-/bfs-path-1.0.2.tgz",
+      "integrity": "sha512-KTKx2JJtAAAT7C/rJYDXXWA2VLPycAS4kwFktKsxUo0hj4UTtw/Gm5PJuY7Uf3xSlIQNo7HRCSWei2ivncVwbQ=="
+    },
     "binary-extensions": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
@@ -2187,6 +2192,11 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-stats": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/fs-stats/-/fs-stats-0.0.0.tgz",
+      "integrity": "sha1-i+clkYLwCU4pyD8JhD3JLEG3EWg="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3111,8 +3121,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -3830,6 +3839,16 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "localstorage-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/localstorage-fs/-/localstorage-fs-0.1.0.tgz",
+      "integrity": "sha1-DaoTqtlzM5krboff1HzoSyiq0wI=",
+      "requires": {
+        "fs-stats": "~0.0.0",
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
       }
     },
     "locate-path": {
@@ -5872,6 +5891,11 @@
       "requires": {
         "parse-ms": "^2.0.0"
       }
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -407,21 +407,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
-    "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/ip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz",
@@ -452,24 +437,6 @@
       "integrity": "sha512-ry4DOrC+xenhQbzk1iIPzCZGhhPGEFv7ia7Iu6XXSLVluiJIe9FfG7Iu3mObH9mpxEXCWLCMU4JWbCCR9Oy1Zg==",
       "dev": true
     },
-    "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
-      "dev": true,
-      "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
-      }
-    },
-    "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
-    },
     "@unleash/client-specification": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@unleash/client-specification/-/client-specification-3.2.0.tgz",
@@ -492,6 +459,7 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
       "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -634,6 +602,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -641,7 +610,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -670,7 +640,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -770,12 +741,23 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-plugin-espower": {
       "version": "3.0.1",
@@ -857,6 +839,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1031,7 +1014,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chai": {
       "version": "4.2.0",
@@ -1236,6 +1220,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1327,7 +1312,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.1.0",
@@ -1395,6 +1381,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1576,7 +1563,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "dir-glob": {
       "version": "2.2.2",
@@ -1615,6 +1603,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1967,7 +1956,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2069,12 +2059,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -2085,7 +2077,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2162,6 +2155,24 @@
         "write": "^0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2171,12 +2182,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -2778,6 +2791,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2888,12 +2902,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -2964,6 +2980,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3199,8 +3216,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -3412,7 +3428,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-url": {
       "version": "1.2.4",
@@ -3453,7 +3470,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3525,7 +3543,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -3542,12 +3561,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3558,7 +3579,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.1.0",
@@ -3573,6 +3595,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4106,12 +4129,14 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -4188,8 +4213,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multimatch": {
       "version": "2.1.0",
@@ -5464,7 +5488,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5738,7 +5763,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -5924,7 +5950,8 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -5939,12 +5966,14 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -6184,6 +6213,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6313,7 +6343,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6327,7 +6358,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.6.0",
@@ -6637,6 +6669,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6960,6 +6993,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -6968,7 +7002,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -7000,6 +7035,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7007,7 +7043,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -7210,6 +7247,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7244,7 +7282,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -7260,6 +7299,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "homepage": "https://github.com/Unleash/unleash-client-node",
   "dependencies": {
+    "bfs-path": "^1.0.2",
+    "localstorage-fs": "^0.1.0",
     "ip": "^1.1.5",
     "murmurhash3js": "^3.0.1",
     "request": "^2.88.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "localstorage-fs": "^0.1.0",
     "ip": "^1.1.5",
     "murmurhash3js": "^3.0.1",
-    "request": "^2.88.0"
+    "axios": "^0.18.0"
   },
   "engines": {
     "node": ">=6",
@@ -48,7 +48,6 @@
     "@types/murmurhash3js": "^3.0.2",
     "@types/nock": "^9.3.0",
     "@types/node": "^11.9.0",
-    "@types/request": "^2.0.8",
     "@unleash/client-specification": "^3.2.0",
     "ava": "^1.0.1",
     "coveralls": "^3.0.0",

--- a/src/integrations/browser-detector.ts
+++ b/src/integrations/browser-detector.ts
@@ -1,0 +1,8 @@
+export const isStandardBrowserEnv = () => {
+    if (typeof navigator !== 'undefined' && (navigator.product === 'ReactNative' ||
+        navigator.product === 'NativeScript' ||
+        navigator.product === 'NS')) {
+        return false;
+    }
+    return (typeof window !== 'undefined' && typeof document !== 'undefined');
+};

--- a/src/integrations/browser/browser-based-storage-utils.ts
+++ b/src/integrations/browser/browser-based-storage-utils.ts
@@ -1,0 +1,7 @@
+import { join } from 'bfs-path';
+//TODO: Once BrowserFS upgrades their "@types/node" to "11.9.0+" we can integrate that, remember BrowserFS is  a superior library
+import * as fs from 'localstorage-fs';
+
+const { readFile, writeFile } = fs;
+
+export { join, readFile, writeFile };

--- a/src/integrations/browser/browser-based-timer-utils.ts
+++ b/src/integrations/browser/browser-based-timer-utils.ts
@@ -1,0 +1,31 @@
+import Timer = NodeJS.Timer;
+
+class BrowserTimeout implements Timer {
+    private _handle: number;
+    
+    constructor(handle: number) {
+        this._handle = handle;
+    }
+    
+    ref(): void {
+    }
+    
+    refresh(): void {
+    }
+    
+    unref(): void {
+    }
+    
+    clear(): void {
+        window.clearInterval(this._handle);
+    }
+}
+
+
+export function browserBasedSetTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer {
+    return new BrowserTimeout(window.setTimeout(callback, ms, ...args));
+}
+
+export function browserBasedClearInterval(intervalId: NodeJS.Timer): void {
+    (intervalId as BrowserTimeout).clear();
+}

--- a/src/integrations/browser/localstorage-fs.d.ts
+++ b/src/integrations/browser/localstorage-fs.d.ts
@@ -1,0 +1,5 @@
+declare module "localstorage-fs" {
+    function readFile(path: string, encoding: string, callback: (err: any, data: any) => void): void;
+    
+    function writeFile(path: string, data: any, callback: (err: any) => void): void;
+}

--- a/src/integrations/node/node-based-storage-utils.ts
+++ b/src/integrations/node/node-based-storage-utils.ts
@@ -1,0 +1,16 @@
+import {join} from 'path';
+
+import * as fs from 'fs';
+
+function readFile(path: string, encoding: string, callback: (err: any, data: any) => void): void {
+    fs.readFile(path, encoding, callback);
+}
+
+function writeFile(path: string, data: any, callback: (err: any) => void): void {
+    fs.writeFile(path, data, callback);
+}
+
+
+export {
+    join, writeFile, readFile
+}

--- a/src/integrations/node/node-based-timer-utils.ts
+++ b/src/integrations/node/node-based-timer-utils.ts
@@ -1,0 +1,8 @@
+export function nodeBasedSetTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer {
+    return setTimeout(callback, ms, ...args);
+}
+
+export function nodeBasedClearInterval(intervalId: NodeJS.Timer): void {
+    clearInterval(intervalId);
+}
+

--- a/src/integrations/storage-utils.ts
+++ b/src/integrations/storage-utils.ts
@@ -1,15 +1,6 @@
+import { isStandardBrowserEnv } from "./browser-detector";
 import * as NodeBasedStorageUtils from './node/node-based-storage-utils';
 import * as BrowserBasedStorageUtils from './browser/browser-based-storage-utils';
-
-const isStandardBrowserEnv = () => {
-    if (typeof navigator !== 'undefined' && (navigator.product === 'ReactNative' ||
-        navigator.product === 'NativeScript' ||
-        navigator.product === 'NS')) {
-        return false;
-    }
-    return (typeof window !== 'undefined' && typeof document !== 'undefined');
-};
-
 
 const resolve = () => isStandardBrowserEnv() ? BrowserBasedStorageUtils : NodeBasedStorageUtils;
 

--- a/src/integrations/storage-utils.ts
+++ b/src/integrations/storage-utils.ts
@@ -1,0 +1,16 @@
+import * as NodeBasedStorageUtils from './node/node-based-storage-utils';
+import * as BrowserBasedStorageUtils from './browser/browser-based-storage-utils';
+
+const isStandardBrowserEnv = () => {
+    if (typeof navigator !== 'undefined' && (navigator.product === 'ReactNative' ||
+        navigator.product === 'NativeScript' ||
+        navigator.product === 'NS')) {
+        return false;
+    }
+    return (typeof window !== 'undefined' && typeof document !== 'undefined');
+};
+
+
+const resolve = () => isStandardBrowserEnv() ? BrowserBasedStorageUtils : NodeBasedStorageUtils;
+
+export default resolve;

--- a/src/integrations/timer-utils.ts
+++ b/src/integrations/timer-utils.ts
@@ -1,0 +1,11 @@
+import { isStandardBrowserEnv } from "./browser-detector";
+import { browserBasedClearInterval, browserBasedSetTimeout } from './browser/browser-based-timer-utils';
+import { nodeBasedClearInterval, nodeBasedSetTimeout } from './node/node-based-timer-utils';
+
+
+const BrowserBasedTimerUtils = { setTimeout: browserBasedSetTimeout, clearInterval: browserBasedClearInterval };
+const NodeBasedTimerUtils = { setTimeout: nodeBasedSetTimeout, clearInterval: nodeBasedClearInterval };
+
+const resolve = () => isStandardBrowserEnv() ? BrowserBasedTimerUtils : NodeBasedTimerUtils;
+
+export default resolve;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -4,6 +4,7 @@ import { post, Data } from './request';
 import { CustomHeaders } from './unleash';
 import { sdkVersion } from './details.json';
 import { AxiosResponse } from "axios";
+import resolveTimerUtils from './integrations/timer-utils';
 
 type Response = AxiosResponse | any;
 
@@ -41,6 +42,7 @@ export default class Metrics extends EventEmitter {
     private timer: NodeJS.Timer | undefined;
     private started: Date;
     private headers?: CustomHeaders;
+    private _timerUtils = resolveTimerUtils();
 
     constructor({
         appName,
@@ -73,7 +75,7 @@ export default class Metrics extends EventEmitter {
         if (this.disabled) {
             return false;
         }
-        this.timer = setTimeout(() => {
+        this.timer = this._timerUtils.setTimeout(() => {
             this.sendMetrics();
         }, this.metricsInterval);
 
@@ -85,7 +87,7 @@ export default class Metrics extends EventEmitter {
 
     stop() {
         if (this.timer) {
-            clearInterval(this.timer);
+            this._timerUtils.clearInterval(this.timer);
             delete this.timer;
         }
         this.disabled = true;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,9 +1,11 @@
 import { EventEmitter } from 'events';
-import { Response } from 'request';
 import { resolve } from 'url';
 import { post, Data } from './request';
 import { CustomHeaders } from './unleash';
 import { sdkVersion } from './details.json';
+import { AxiosResponse } from "axios";
+
+type Response = AxiosResponse | any;
 
 export interface MetricsOptions {
     appName: string;
@@ -103,14 +105,14 @@ export default class Metrics extends EventEmitter {
                 instanceId: this.instanceId,
                 headers: this.headers,
             },
-            (err: Error | null, res: Response, body: any) => {
+            (err: Error | null, res: AxiosResponse | any, body: any) => {
                 if (err) {
                     this.emit('error', err);
                     return;
                 }
 
-                if (!(res.statusCode && res.statusCode >= 200 && res.statusCode < 300)) {
-                    this.emit('warn', `${url} returning ${res.statusCode}`, body);
+                if (!(res.status && res.status >= 200 && res.status < 300)) {
+                    this.emit('warn', `${url} returning ${res.status}`, body);
                     return;
                 }
                 this.emit('registered', payload);
@@ -145,14 +147,14 @@ export default class Metrics extends EventEmitter {
                     return;
                 }
 
-                if (res.statusCode === 404) {
+                if (res.status === 404) {
                     this.emit('warn', `${url} returning 404, stopping metrics`);
                     this.stop();
                     return;
                 }
 
-                if (!(res.statusCode && res.statusCode >= 200 && res.statusCode < 300)) {
-                    this.emit('warn', `${url} returning ${res.statusCode}`, body);
+                if (!(res.status && res.status >= 200 && res.status < 300)) {
+                    this.emit('warn', `${url} returning ${res.status}`, body);
                     return;
                 }
                 this.emit('sent', payload);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -5,6 +5,7 @@ import { resolve } from 'url';
 import { get } from './request';
 import { CustomHeaders } from './unleash';
 import { AxiosResponse } from "axios";
+import resolveTimerUtils from './integrations/timer-utils';
 
 type Response = AxiosResponse | any;
 
@@ -29,6 +30,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     private instanceId: string;
     private refreshInterval?: number;
     private headers?: CustomHeaders;
+    private _timerUtils = resolveTimerUtils();
 
     constructor({
         backupPath,
@@ -55,7 +57,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
     timedFetch() {
         if (this.refreshInterval != null && this.refreshInterval > 0) {
-            this.timer = setTimeout(() => this.fetch(), this.refreshInterval);
+            this.timer = this._timerUtils.setTimeout(() => this.fetch(), this.refreshInterval);
             if (process.env.NODE_ENV !== 'test') {
                 this.timer.unref();
             }
@@ -138,7 +140,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
     stop() {
         if (this.timer) {
-            clearInterval(this.timer);
+            this._timerUtils.clearInterval(this.timer);
         }
         this.removeAllListeners();
         this.storage.removeAllListeners();

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,7 +4,9 @@ import { FeatureInterface } from './feature';
 import { resolve } from 'url';
 import { get } from './request';
 import { CustomHeaders } from './unleash';
-import { Response } from 'request';
+import { AxiosResponse } from "axios";
+
+type Response = AxiosResponse | any;
 
 export type StorageImpl = typeof Storage;
 
@@ -100,20 +102,20 @@ export default class Repository extends EventEmitter implements EventEmitter {
                     return this.emit('error', error);
                 }
 
-                if (res.statusCode === 304) {
+                if (res.status === 304) {
                     // No new data
                     return;
                 }
 
-                if (!(res.statusCode >= 200 && res.statusCode < 300)) {
+                if (!(res.status >= 200 && res.status < 300)) {
                     return this.emit(
                         'error',
-                        new Error(`Response was not statusCode 2XX, but was ${res.statusCode}`),
+                        new Error(`Response was not statusCode 2XX, but was ${res.status}`),
                     );
                 }
 
                 try {
-                    const data: any = JSON.parse(body);
+                    const data = typeof body === "string" ? JSON.parse(body) : body;
                     const obj = data.features.reduce(
                         (o: { [s: string]: FeatureInterface }, feature: FeatureInterface) => {
                             this.validateFeature(feature);

--- a/src/request.ts
+++ b/src/request.ts
@@ -42,7 +42,9 @@ const attachCallbackTo = <T = any>(promise: Promise<AxiosResponse<T>>, cb: Reque
         });
 
 const deleteUndefinedHeaders = (headers: any) =>
-    Object.entries(headers)
+    //TODO: Travis runs the build on node6, which does not support Object.entries
+    Object.keys(headers)
+        .map(key => [key, headers[key]])
         .filter(([key, value]) => value === undefined)
         .forEach(([key]) => delete headers[key]);
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,11 @@
-import * as request from 'request';
 import { CustomHeaders } from './unleash';
+import axios, { AxiosResponse } from 'axios';
+
+type RequestCallback<T = any> = (
+    error: Error | null,
+    response: AxiosResponse<T> | null,
+    data: any,
+) => void;
 
 export interface RequestOptions {
     url: string;
@@ -23,9 +29,26 @@ export interface PostRequestOptions extends RequestOptions {
     instanceId?: string;
 }
 
+const isA2XXResponse = (res: any) => res.status >= 200 && res.status < 300;
+const isAValidNon2XXResponse = (res: any) => res && !isA2XXResponse(res);
+
+const attachCallbackTo = <T = any>(promise: Promise<AxiosResponse<T>>, cb: RequestCallback) =>
+    promise
+        .then(response => cb(null, response, response.data))
+        .catch(reason => {
+            const res = reason.response;
+            const error = isAValidNon2XXResponse(res) ? null : reason;
+            cb(error, res, res && res.data);
+        });
+
+const deleteUndefinedHeaders = (headers: any) =>
+    Object.entries(headers)
+        .filter(([key, value]) => value === undefined)
+        .forEach(([key]) => delete headers[key]);
+
 export const post = (
     { url, appName, timeout, instanceId, headers, json }: PostRequestOptions,
-    cb: request.RequestCallback,
+    cb: RequestCallback,
 ) => {
     const options = {
         url,
@@ -38,14 +61,15 @@ export const post = (
             },
             headers,
         ),
-        json,
     };
-    return request.post(options, cb);
+
+    deleteUndefinedHeaders(options.headers);
+    return attachCallbackTo(axios.post(url, json, options), cb);
 };
 
 export const get = (
     { url, etag, appName, timeout, instanceId, headers }: GetRequestOptions,
-    cb: request.RequestCallback,
+    cb: RequestCallback,
 ) => {
     const options = {
         url,
@@ -62,5 +86,7 @@ export const get = (
     if (etag) {
         options.headers['If-None-Match'] = etag;
     }
-    return request.get(options, cb);
+
+    deleteUndefinedHeaders(options.headers);
+    return attachCallbackTo(axios.get(url, options), cb);
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
-import { join } from 'path';
-import { writeFile, readFile } from 'fs';
+import resolveStorageUtils from './integrations/storage-utils';
 
 export interface StorageOptions {
     backupPath: string;
@@ -13,11 +12,15 @@ export class Storage extends EventEmitter implements EventEmitter {
     private ready: boolean = false;
     private data: any;
     private path: string;
+    private _utils = resolveStorageUtils();
 
     constructor({ backupPath, appName }: StorageOptions) {
         super();
         this.data = {};
-        this.path = join(backupPath, `/unleash-repo-schema-v1-${this.safeAppName(appName)}.json`);
+        this.path = this._utils.join(
+            backupPath,
+            `/unleash-repo-schema-v1-${this.safeAppName(appName)}.json`,
+        );
         this.load();
     }
 
@@ -44,7 +47,7 @@ export class Storage extends EventEmitter implements EventEmitter {
     }
 
     persist(): void {
-        writeFile(this.path, JSON.stringify(this.data), err => {
+        this._utils.writeFile(this.path, JSON.stringify(this.data), err => {
             if (err) {
                 return this.emit('error', err);
             }
@@ -53,7 +56,7 @@ export class Storage extends EventEmitter implements EventEmitter {
     }
 
     load(): void {
-        readFile(this.path, 'utf8', (err, data: string) => {
+        this._utils.readFile(this.path, 'utf8', (err, data: string) => {
             if (this.ready) {
                 return;
             }

--- a/test/integrations/timer-utils.test.js
+++ b/test/integrations/timer-utils.test.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import resolveTimerUtils from '../../lib/integrations/timer-utils';
+
+// Mini mock library
+const mockFn = () => {
+    const mockFnInstance = (...args) => {
+        mockFnInstance.lastCalledArguments = [...args];
+        return mockFnInstance.returnValue;
+    };
+
+    mockFnInstance.mockReturnValue = returnValue => (mockFnInstance.returnValue = returnValue);
+    return mockFnInstance;
+};
+
+const expect = (t, mock) => ({
+    toHaveBeenCalledWith: (...expectedArgs) => {
+        t.deepEqual(mock.lastCalledArguments, [...expectedArgs]);
+    },
+});
+// //////////////////
+
+let windowObj;
+
+test.beforeEach(() => {
+    global.navigator = { product: 'fake-browser' };
+    global.window = {
+        setTimeout: mockFn(),
+        clearInterval: mockFn(),
+    };
+    global.document = {};
+    windowObj = global.window;
+});
+
+test('should able to set timeouts', t => {
+    const timerUtils = resolveTimerUtils();
+    const someCallBackFn = () => {};
+    const timeoutInMs = 100;
+    const arg1 = 'pi';
+    const arg2 = 2.33;
+
+    timerUtils.setTimeout(someCallBackFn, timeoutInMs, arg1, arg2);
+
+    expect(t, windowObj.setTimeout).toHaveBeenCalledWith(someCallBackFn, timeoutInMs, arg1, arg2);
+});
+
+test('should able to set and clear timeouts', t => {
+    const timerUtils = resolveTimerUtils();
+    const handle = 27;
+    const someCallBackFn = () => {};
+    windowObj.setTimeout.mockReturnValue(handle);
+
+    const timeout = timerUtils.setTimeout(someCallBackFn, 100);
+    timerUtils.clearInterval(timeout);
+
+    expect(t, windowObj.clearInterval).toHaveBeenCalledWith(handle);
+});

--- a/test/storage-browser.test.js
+++ b/test/storage-browser.test.js
@@ -1,0 +1,197 @@
+import test from 'ava';
+import { Storage } from '../lib/storage';
+import { join } from 'bfs-path';
+// TODO: Dear God at some point we will move to Browser-FS, see browser-based-storage-utils.ts
+import * as fs from 'localstorage-fs';
+
+const mkdirpSync = fullPath =>
+    fullPath
+        .split('/')
+        .map((_ignore, i, parts) => parts.slice(0, i + 1).join('/'))
+        .filter(t => t !== '')
+        .forEach(path => fs.existsSync(path) || fs.mkdirSync(path));
+
+let mockLocalStorage = (memoryBag = {}) => ({
+    getItem: key => memoryBag[key] || null,
+    setItem: (key, value) => (memoryBag[key] = value),
+});
+
+test.beforeEach(() => {
+    global.navigator = { product: 'fake-browser' };
+    global.window = {};
+    global.document = {};
+    global.localStorage = mockLocalStorage();
+});
+
+// Porting dependencies
+const { writeFileSync } = fs;
+const mkdirp = { sync: mkdirpSync };
+const tmpdir = () => '/tmp/aabbccdd';
+
+// Same as storage.test.js
+
+function setup(name) {
+    const tmp = join(tmpdir(), name + Math.round(10000 * Math.random()));
+    mkdirp.sync(tmp);
+    const storage = new Storage({ backupPath: tmp, appName: 'test' });
+
+    storage.on('error', err => {
+        throw err;
+    });
+    return storage;
+}
+
+test('should load content from backup file', t =>
+    new Promise((resolve, reject) => {
+        const tmp = join(tmpdir(), 'backup-file-test');
+        mkdirp.sync(tmp);
+        const storage = new Storage({ backupPath: tmp, appName: 'test' });
+        const data = { random: Math.random() };
+        storage.on('error', reject);
+
+        storage.once('persisted', () => {
+            t.true(storage.get('random') === data.random);
+
+            const storage2 = new Storage({ backupPath: tmp, appName: 'test' });
+            storage2.on('error', reject);
+            storage2.on('ready', () => {
+                t.true(storage2.get('random') === data.random);
+                resolve();
+            });
+        });
+        storage.reset(data);
+    }));
+
+test('should handle complex appNames', t =>
+    new Promise((resolve, reject) => {
+        const tmp = join(tmpdir(), 'backup-file-test');
+        mkdirp.sync(tmp);
+        const appName = '@namspace-dash/slash-some-app';
+        const storage = new Storage({ backupPath: tmp, appName });
+        const data = { random: Math.random() };
+        storage.on('error', reject);
+
+        storage.once('persisted', () => {
+            t.true(storage.get('random') === data.random);
+
+            const storage2 = new Storage({ backupPath: tmp, appName });
+            storage2.on('error', reject);
+            storage2.on('ready', () => {
+                t.true(storage2.get('random') === data.random);
+                resolve();
+            });
+        });
+        storage.reset(data);
+    }));
+
+test.cb('should emit error when non-existent target backupPath', t => {
+    const storage = new Storage({
+        backupPath: join(tmpdir(), `random-${Math.round(Math.random() * 10000)}`),
+        appName: 'test',
+    });
+    storage.reset({ random: Math.random() });
+    storage.on('error', err => {
+        t.truthy(err);
+        t.true(err.code === 'ENOENT');
+        t.end();
+    });
+});
+
+test.cb('should emit error when stored data is invalid', t => {
+    const dir = join(tmpdir(), `random-${Math.round(Math.random() * 10123000)}`);
+    mkdirp.sync(dir);
+    writeFileSync(join(dir, 'unleash-repo-schema-v1-test.json'), '{invalid: json, asd}', 'utf8');
+    const storage = new Storage({
+        backupPath: dir,
+        appName: 'test',
+    });
+    storage.on('persisted', console.log);
+    storage.on('error', err => {
+        t.truthy(err);
+        t.regex(err.message, /Unexpected token/);
+        t.end();
+    });
+});
+
+test('should not write content from backup file if ready has been fired', t =>
+    new Promise((resolve, reject) => {
+        const tmp = join(tmpdir(), 'ignore-backup-file-test');
+        mkdirp.sync(tmp);
+        const storage = new Storage({
+            backupPath: tmp,
+            appName: 'test',
+        });
+        const data = { random: Math.random() };
+        storage.on('error', reject);
+
+        storage.once('persisted', () => {
+            t.true(storage.get('random') === data.random);
+
+            const storage2 = new Storage({
+                backupPath: tmp,
+                appName: 'test',
+            });
+            const overwrite = { random: Math.random() };
+
+            storage2.on('error', reject);
+            storage2.on('ready', () => {
+                t.true(storage2.get('random') !== data.random);
+                t.true(storage2.get('random') === overwrite.random);
+                resolve();
+            });
+
+            // Lets pretend "server" finished read first
+            storage2.reset(overwrite);
+        });
+        storage.reset(data);
+    }));
+
+test('should provide Get method from data', t => {
+    const storage = setup('get-method');
+    const result = storage.get('some-key');
+
+    t.true(result === undefined);
+
+    storage.reset({ 'some-key': 'some-value' });
+
+    const result2 = storage.get('some-key');
+
+    t.true(result2 === 'some-value');
+});
+
+test('should persist data on reset', t =>
+    new Promise(resolve => {
+        const storage = setup('persist');
+        const data = { random: Math.random() };
+
+        storage.once('persisted', () => {
+            t.true(storage.get('random') === data.random);
+            resolve();
+        });
+
+        t.true(storage.get('random') !== data.random);
+        storage.reset(data);
+        t.true(storage.get('random') === data.random);
+    }));
+
+test('should persist again after data reset', t =>
+    new Promise(resolve => {
+        const storage = setup('persist2');
+        const data = { random: Math.random() };
+
+        storage.once('persisted', () => {
+            t.true(storage.get('random') === data.random);
+            const data2 = { random: Math.random() };
+
+            storage.once('persisted', () => {
+                t.true(storage.get('random') === data2.random);
+                resolve();
+            });
+
+            storage.reset(data2);
+        });
+
+        t.true(storage.get('random') !== data.random);
+        storage.reset(data);
+        t.true(storage.get('random') === data.random);
+    }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "lib": ["es5", "es6"],
+    "lib": ["es5", "es6", "dom"],
     "target": "es5",
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
### Purpose : 
Add support for browsers to this client so that it can be used in both node based backend as well as front apps
Right now available solution "Unleash Client React" does not support all features of unleash and that is only useable in react apps. 
On the other hand this client can be used in any javascript application. 

### How?

1. Added [localstorage-fs](https://www.npmjs.com/package/localstorage-fs) to replicate NodeJs fs on frontend and store toggles state in browser
2. Added [bfs-path](https://www.npmjs.com/package/bfs-path) to replicate NodeJs path library
3. Replaced [request](https://www.npmjs.com/package/request) library with [axios](https://www.npmjs.com/package/axios) since axios works with both browser and node js
4. Given compatible class for "NodeJs.Timer" interface

### What's next? 
Replace [localstorage-fs](https://www.npmjs.com/package/localstorage-fs) with [BrowserFS](https://www.npmjs.com/package/browserfs) so that a variety of storage medium (e.g. localstorage, indexed db,...) can be used. This can not be done right now as BrowserFs uses an older version of @types/node 

### Additional : 

- Duplicated test cases for Storage.ts to verify it works fine with localstorage implementation. 
- Tested with one react single page app using webpack

