### PR TITLE
feature: inject repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,38 @@ instance.on('ready', console.log.bind(console, 'ready'));
 instance.on('error', console.error);
 ```
 
+## Events
+
+The unleash instance object implements the EventEmitter class and **emits** the following events:
+
+| event      | payload                          | description                                                                              |
+| ---------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| ready      | -                                | is emitted once the fs-cache is ready. if no cache file exists it will still be emitted. |
+| registered | -                                | is emitted after the app has been registered at the api server                           |
+| sent       | `object` data                    | key/value pair of delivered metrics                                                      |
+| count      | `string` name, `boolean` enabled | is emitted when a feature is evaluated                                                   |
+| warn       | `string` msg                     | is emitted on a warning                                                                  |
+| error      | `Error` err                      | is emitted on a error                                                                    |
+
+Example usage:
+
+```js
+const { Unleash, isEnabled } = require('unleash-client');
+
+const instance = new Unleash({
+    appName: 'my-app-name',
+    url: 'http://unleash.herokuapp.com',
+});
+
+await instance.once('ready');
+// do something
+```
+
 ## Custom repository
 
 You can manage the underlying data layer yourself if you want to. This enables you to use unleash
 offline, from a browser environment or implement your own caching layer. See
 [example](examples/custom_repository.js).
+
+Unleash depends on a `ready` event of the repository you pass in. Be sure that you emit the event
+**after** you've initialized unleash.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The initialize method takes the following arguments:
 -   **disableMetrics** - disable metrics
 -   **customHeaders** - Provide a map(object) of custom headers to be sent to the unleash-server
 -   **timeout** - specify a timeout in milliseconds for outgoing HTTP requests. Defaults to 10000ms.
+-   **repository** - Provide a custom repository implementation to manage the underlying data
 
 ## Custom strategies
 
@@ -153,3 +154,9 @@ instance.on('ready', console.log.bind(console, 'ready'));
 // required error handling when using instance directly
 instance.on('error', console.error);
 ```
+
+## Custom repository
+
+You can manage the underlying data layer yourself if you want to. This enables you to use unleash
+offline, from a browser environment or implement your own caching layer. See
+[example](examples/custom_repository.js).

--- a/examples/custom_repository.js
+++ b/examples/custom_repository.js
@@ -1,0 +1,34 @@
+const { EventEmitter } = require('events');
+const { initialize, isEnabled } = require('../lib');
+
+class MyRepo extends EventEmitter {
+    constructor() {
+        super();
+        this.data = {
+            name: 'my-feature',
+            description: 'foo',
+            enabled: true,
+            strategies: [],
+            variants: [],
+        };
+    }
+    stop() {
+        return;
+    }
+    getToggle() {
+        return this.data;
+    }
+}
+const repo = new MyRepo();
+const client = initialize({
+    appName: 'my-application',
+    url: 'not-needed',
+    disableMetrics: true,
+    repository: repo,
+});
+repo.emit('ready');
+
+client.on('error', console.error);
+client.on('warn', console.log);
+
+console.log(`feature enabled: ${isEnabled('THE-feature')}`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { Strategy, StrategyTransportInterface } from './strategy';
 import { FeatureInterface } from './feature';
-import Repository from './repository';
+import { RepositoryInterface } from './repository';
 import { Variant, getDefaultVariant, VariantDefinition, selectVariant } from './variant';
 import { Context } from './context';
 
@@ -10,11 +10,11 @@ interface BooleanMap {
 }
 
 export default class UnleashClient extends EventEmitter {
-    private repository: Repository;
+    private repository: RepositoryInterface;
     private strategies: Strategy[];
     private warned: BooleanMap;
 
-    constructor(repository: Repository, strategies: Strategy[]) {
+    constructor(repository: RepositoryInterface, strategies: Strategy[]) {
         super();
         this.repository = repository;
         this.strategies = strategies || [];

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -8,6 +8,11 @@ import { Response } from 'request';
 
 export type StorageImpl = typeof Storage;
 
+export interface RepositoryInterface extends EventEmitter {
+    getToggle(name: string): FeatureInterface;
+    stop(): void;
+}
+
 export interface RepositoryOptions {
     backupPath: string;
     url: string;

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -1,5 +1,5 @@
 import Client from './client';
-import Repository from './repository';
+import Repository, { RepositoryInterface } from './repository';
 import Metrics from './metrics';
 import { Strategy, defaultStrategies } from './strategy';
 export { Strategy };
@@ -26,10 +26,11 @@ export interface UnleashConfig {
     strategies?: Strategy[];
     customHeaders?: CustomHeaders;
     timeout?: number;
+    repository?: RepositoryInterface;
 }
 
 export class Unleash extends EventEmitter {
-    private repository: Repository;
+    private repository: RepositoryInterface;
     private client: Client | undefined;
     private metrics: Metrics;
 
@@ -42,6 +43,7 @@ export class Unleash extends EventEmitter {
         disableMetrics = false,
         backupPath = BACKUP_PATH,
         strategies = [],
+        repository,
         customHeaders,
         timeout,
     }: UnleashConfig) {
@@ -84,15 +86,17 @@ export class Unleash extends EventEmitter {
             instanceId = `${prefix}-${hostname()}`;
         }
 
-        this.repository = new Repository({
-            backupPath,
-            url,
-            appName,
-            instanceId,
-            refreshInterval,
-            headers: customHeaders,
-            timeout,
-        });
+        this.repository =
+            repository ||
+            new Repository({
+                backupPath,
+                url,
+                appName,
+                instanceId,
+                refreshInterval,
+                headers: customHeaders,
+                timeout,
+            });
 
         strategies = defaultStrategies.concat(strategies);
 


### PR DESCRIPTION
Here's the PR to inject the repository. PTAL when you have time. 

What's missing from the docs:
* repository events: `data, ready, error`
* metrics events: `warn, error, registered, sent`
* storage events: `ready, persisted, error`
* client events: `warn, error`

I wasn't sure whether or not a user of this SDK should depend on the implementation details of the `repository`, `storage`, `metrics` and `client` objects. That makes changing the underlying implementation really hard. That's why i would discourage documenting that.
Though, it certainly is possible to access the internals and to subscribe to those events.
Please let me know if you want to have that documented, too. I'll add them in a separate PR.