### PR TITLE
fix: Strategy gradualRolloutRandom random should <= 100

### DIFF
--- a/src/strategy/gradual-rollout-random.ts
+++ b/src/strategy/gradual-rollout-random.ts
@@ -8,7 +8,7 @@ export class GradualRolloutRandomStrategy extends Strategy {
 
     isEnabled(parameters: any, context: Context) {
         const percentage: number = Number(parameters.percentage);
-        const random: number = Math.round(Math.random() * 100) + 1;
+        const random: number = Math.floor(Math.random() * 100) + 1;
         return percentage >= random;
     }
 }

--- a/test/strategy/gradual-rollout-random.test.js
+++ b/test/strategy/gradual-rollout-random.test.js
@@ -36,3 +36,9 @@ test('gradual-rollout-random strategy should be disabled when percentage=0', t =
     let params = { percentage: '0', groupId: 'test' };
     t.false(strategy.isEnabled(params));
 });
+
+test('gradual-rollout-random strategy should be enabled when percentage=100', t => {
+    const strategy = new GradualRolloutRandomStrategy();
+    let params = { percentage: '100', groupId: 'test' };
+    t.true(strategy.isEnabled(params));
+});


### PR DESCRIPTION
Fix for #131 
When I set parameters for gradualRolloutRandom as `100%`，it means always enabled.
 