### PR TITLE
feat: Add support for static context fields

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,5 +3,7 @@ export interface Context {
     userId?: string;
     sessionId?: string;
     remoteAddress?: string;
+    environment?: string;
+    appName?: string;
     properties?: any;
 }


### PR DESCRIPTION
Added support for two new static context fields:
- environment
- appName

These are set in the Configuration when the client is
initialized and should be inserted in to the UnleashContext.

closes #135