### PR TITLE
fix: ensure destroy works more consistently

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -37,6 +37,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     private headers?: CustomHeaders;
     private customHeadersFunction?: CustomHeadersFunction;
     private timeout?: number;
+    private stopped = false;
 
     constructor({
         backupPath,
@@ -97,6 +98,9 @@ export default class Repository extends EventEmitter implements EventEmitter {
     }
 
     async fetch() {
+        if (this.stopped) {
+            return;
+        }
         const url = resolve(this.url, './client/features');
 
         const headers = this.customHeadersFunction
@@ -155,8 +159,9 @@ export default class Repository extends EventEmitter implements EventEmitter {
     }
 
     stop() {
+        this.stopped = true;
         if (this.timer) {
-            clearInterval(this.timer);
+            clearTimeout(this.timer);
         }
         this.removeAllListeners();
         this.storage.removeAllListeners();

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -77,6 +77,19 @@ test('should error when missing url', t => {
     t.throws(() => new Unleash({ url: 'http://unleash.github.io', appName: false }));
 });
 
+test('calling destroy synchronously should avoid network activity', t => {
+    const url = getUrl();
+    // Don't call mockNetwork. If destroy didn't work, then we would have an
+    // uncaught exception.
+    const instance = new Unleash({
+        appName: 'foo',
+        url,
+        disableMetrics: true,
+    });
+    instance.destroy();
+    t.true(true);
+});
+
 test.cb('should handle old url', t => {
     const url = mockNetwork([]);
 


### PR DESCRIPTION
Previously, if `unleash.destroy()` is called synchronously after Unleash
creation (before `process.nextTick(() => this.fetch())` is called), or while the
request `get` is in progress, polling would not actually stop.  Now we
consistently stop polling if `repository.stop()` is ever called.

Also use clearTimeout instead of clearInterval.