### PR TITLE
fix: Only unref timers when used in node, where unref is defined

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -83,7 +83,7 @@ export default class Metrics extends EventEmitter {
             this.sendMetrics();
         }, this.metricsInterval);
 
-        if (process.env.NODE_ENV !== 'test') {
+        if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
             this.timer.unref();
         }
         return true;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -60,7 +60,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
         this.customHeadersFunction = customHeadersFunction;
 
         this.storage = new StorageImpl({ backupPath, appName });
-        this.storage.on('error', err => this.emit('error', err));
+        this.storage.on('error', (err) => this.emit('error', err));
         this.storage.on('ready', () => this.emit('ready'));
 
         process.nextTick(() => this.fetch());
@@ -69,7 +69,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     timedFetch() {
         if (this.refreshInterval != null && this.refreshInterval > 0) {
             this.timer = setTimeout(() => this.fetch(), this.refreshInterval);
-            if (process.env.NODE_ENV !== 'test') {
+            if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
                 this.timer.unref();
             }
         }
@@ -174,6 +174,6 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
     getToggles(): FeatureInterface[] {
         const toggles = this.storage.getAll();
-        return Object.keys(toggles).map(key => toggles[key]);
+        return Object.keys(toggles).map((key) => toggles[key]);
     }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -60,7 +60,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
         this.customHeadersFunction = customHeadersFunction;
 
         this.storage = new StorageImpl({ backupPath, appName });
-        this.storage.on('error', (err) => this.emit('error', err));
+        this.storage.on('error', err => this.emit('error', err));
         this.storage.on('ready', () => this.emit('ready'));
 
         process.nextTick(() => this.fetch());
@@ -174,6 +174,6 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
     getToggles(): FeatureInterface[] {
         const toggles = this.storage.getAll();
-        return Object.keys(toggles).map((key) => toggles[key]);
+        return Object.keys(toggles).map(key => toggles[key]);
     }
 }


### PR DESCRIPTION
Resolves #187. The library could not be used in Electron because Electron seems to not use `setTimeout` from Node, and therefore the `unref` method does not exist. The library seems to be working without that method when running inside a render process, so this might be a solution. Not sure about if this is a solid solution, how about it? 