### PR TITLE
feat: Expose Context and Variant interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Variant, getDefaultVariant } from './variant';
 import { Context } from './context';
 
 export { Strategy } from './strategy/index';
-export { Unleash } from './unleash';
+export { Context, Variant, Unleash };
 
 let instance: Unleash | undefined;
 export function initialize(options: UnleashConfig): Unleash {


### PR DESCRIPTION
When using `unleash-client` in a TypeScript setting it's to have public interfaces available directly instead of having to import from internals:

Before:

```ts
import type { Context } from 'unleash-client/lib/context';
import type { Variant } from 'unleash-client/lib/variant';
```

After:

```ts
import type { Context, Variant } from 'unleash-client';
```