### PR TITLE
Clarify that toggle states are available on ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,16 +172,16 @@ instance.on('error', console.error);
 
 The unleash instance object implements the EventEmitter class and **emits** the following events:
 
-| event      | payload                          | description                                                                                 |
-| ---------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
-| ready      | -                                | is emitted once the fs-cache is ready. if no cache file exists it will still be emitted.    |
-| registered | -                                | is emitted after the app has been registered at the api server                              |
-| sent       | `object` data                    | key/value pair of delivered metrics                                                         |
-| count      | `string` name, `boolean` enabled | is emitted when a feature is evaluated                                                      |
-| warn       | `string` msg                     | is emitted on a warning                                                                     |
-| error      | `Error` err                      | is emitted on a error                                                                       |
-| unchanged  | -                                | is emitted each time the client gets new toggle state from server, but nothing has changed  |
-| changed    | `object` data                    | is emitted each time the client gets new toggle state from server and changes has been made |
+| event      | payload                          | description                                                                                                                        |
+| ---------- | -------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------|
+| ready      | -                                | is emitted once the fs-cache is ready. if no cache file exists it will still be emitted. toggle states are available at this point |
+| registered | -                                | is emitted after the app has been registered at the api server                                                                     |
+| sent       | `object` data                    | key/value pair of delivered metrics                                                                                                |
+| count      | `string` name, `boolean` enabled | is emitted when a feature is evaluated                                                                                             |
+| warn       | `string` msg                     | is emitted on a warning                                                                                                            |
+| error      | `Error` err                      | is emitted on a error                                                                                                              |
+| unchanged  | -                                | is emitted each time the client gets new toggle state from server, but nothing has changed                                         |
+| changed    | `object` data                    | is emitted each time the client gets new toggle state from server and changes has been made                                        |
 |            |
 
 Example usage:


### PR DESCRIPTION
We introduced a connection state to ensure a test will be deactivated if our client-instance lose connection to Unleash and we need to deactivate. Ended up having a discussion and code-safari to ensure we are actually ready at the ready-event.