### PR TITLE
feat: flexible rollout - custom stickiness

### DIFF
--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -33,7 +33,6 @@ export class FlexibleRolloutStrategy extends Strategy {
         const groupId = parameters.groupId || context.featureToggle || '';
         const percentage = Number(parameters.rollout);
         const stickiness: string = parameters.stickiness || STICKINESS.default;
-
         const stickinessId = this.resolveStickiness(stickiness, context);
 
         if (!stickinessId) {

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -4,6 +4,7 @@ import { normalizedValue } from './util';
 
 const STICKINESS = {
     default: 'default',
+    custom: 'custom',
     userId: 'userId',
     sessionId: 'sessionId',
     random: 'random',
@@ -19,12 +20,14 @@ export class FlexibleRolloutStrategy extends Strategy {
         }
     }
 
-    resolveStickiness(stickiness: string, context: Context): any {
+    resolveStickiness(stickiness: string, context: Context, customField?: string): any {
         switch (stickiness) {
             case STICKINESS.userId:
                 return context.userId;
             case STICKINESS.sessionId:
                 return context.sessionId;
+            case STICKINESS.custom:
+                return customField ? context[customField] : null;
             case STICKINESS.random:
                 return this.randomGenerator();
             default:
@@ -36,7 +39,7 @@ export class FlexibleRolloutStrategy extends Strategy {
         const groupId = parameters.groupId || context.featureToggle || '';
         const percentage = Number(parameters.rollout);
         const stickiness = parameters.stickiness || STICKINESS.default;
-        const stickinessId = this.resolveStickiness(stickiness, context);
+        const stickinessId = this.resolveStickiness(stickiness, context, parameters.customField);
 
         if (!stickinessId) {
             return false;

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -33,6 +33,7 @@ export class FlexibleRolloutStrategy extends Strategy {
         const groupId = parameters.groupId || context.featureToggle || '';
         const percentage = Number(parameters.rollout);
         const stickiness: string = parameters.stickiness || STICKINESS.default;
+
         const stickinessId = this.resolveStickiness(stickiness, context);
 
         if (!stickinessId) {

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -18,21 +18,21 @@ export class FlexibleRolloutStrategy extends Strategy {
         }
     }
 
-    resolveStickiness(stickiness: string | undefined, context: Context): any {
+    resolveStickiness(stickiness: string, context: Context): any {
         switch (stickiness) {
             case STICKINESS.default:
                 return context.userId || context.sessionId || this.randomGenerator();
             case STICKINESS.random:
                 return this.randomGenerator();
             default:
-                return stickiness ? resolveContextValue(context, stickiness) : null;
+                return resolveContextValue(context, stickiness);
         }
     }
 
     isEnabled(parameters: any, context: Context) {
         const groupId = parameters.groupId || context.featureToggle || '';
         const percentage = Number(parameters.rollout);
-        const stickiness = parameters.stickiness || STICKINESS.default;
+        const stickiness: string = parameters.stickiness || STICKINESS.default;
         const stickinessId = this.resolveStickiness(stickiness, context);
 
         if (!stickinessId) {

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -4,9 +4,6 @@ import { normalizedValue } from './util';
 
 const STICKINESS = {
     default: 'default',
-    custom: 'custom',
-    userId: 'userId',
-    sessionId: 'sessionId',
     random: 'random',
 };
 
@@ -20,18 +17,14 @@ export class FlexibleRolloutStrategy extends Strategy {
         }
     }
 
-    resolveStickiness(stickiness: string, context: Context, customField?: string): any {
+    resolveStickiness(stickiness: string | undefined, context: Context): any {
         switch (stickiness) {
-            case STICKINESS.userId:
-                return context.userId;
-            case STICKINESS.sessionId:
-                return context.sessionId;
-            case STICKINESS.custom:
-                return customField ? context[customField] : null;
+            case STICKINESS.default:
+                return context.userId || context.sessionId || this.randomGenerator();
             case STICKINESS.random:
                 return this.randomGenerator();
             default:
-                return context.userId || context.sessionId || this.randomGenerator();
+                return stickiness ? context[stickiness] : null;
         }
     }
 
@@ -39,7 +32,7 @@ export class FlexibleRolloutStrategy extends Strategy {
         const groupId = parameters.groupId || context.featureToggle || '';
         const percentage = Number(parameters.rollout);
         const stickiness = parameters.stickiness || STICKINESS.default;
-        const stickinessId = this.resolveStickiness(stickiness, context, parameters.customField);
+        const stickinessId = this.resolveStickiness(stickiness, context);
 
         if (!stickinessId) {
             return false;

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -1,6 +1,7 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
 import { normalizedValue } from './util';
+import { resolveContextValue } from '../helpers';
 
 const STICKINESS = {
     default: 'default',
@@ -24,7 +25,7 @@ export class FlexibleRolloutStrategy extends Strategy {
             case STICKINESS.random:
                 return this.randomGenerator();
             default:
-                return stickiness ? context[stickiness] : null;
+                return stickiness ? resolveContextValue(context, stickiness) : null;
         }
     }
 

--- a/test/strategy/flexible-rollout-test.js
+++ b/test/strategy/flexible-rollout-test.js
@@ -47,33 +47,24 @@ test('should NOT be enabled for rollout=10% when userId is 123', t => {
     t.false(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when stickiness=custom and contextField not specified', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = { rollout: '100', stickiness: 'custom', groupId: 'Demo' };
-    const context = {};
-    t.false(strategy.isEnabled(params, context));
-});
-
-test('should be disabled when stickiness=custom and contextField not found', t => {
+test('should be disabled when stickiness=customerId and contextField not found', t => {
     const strategy = new FlexibleRolloutStrategy();
     const params = {
         rollout: '100',
-        stickiness: 'custom',
+        stickiness: 'customerId',
         groupId: 'Demo',
-        contextField: 'customerId',
     };
     const context = {};
     t.false(strategy.isEnabled(params, context));
 });
 
-test('should be enabled when stickiness=custom , customField=customerId and customerId=61', t => {
+test('should be enabled when stickiness=customerId and customerId=61', t => {
     const strategy = new FlexibleRolloutStrategy();
     const params = {
         rollout: '100',
-        stickiness: 'custom',
+        stickiness: 'customerId',
         groupId: 'Demo',
-        contextField: 'customerId',
     };
     const context = { customerId: 61 };
-    t.false(strategy.isEnabled(params, context));
+    t.true(strategy.isEnabled(params, context));
 });

--- a/test/strategy/flexible-rollout-test.js
+++ b/test/strategy/flexible-rollout-test.js
@@ -46,3 +46,34 @@ test('should NOT be enabled for rollout=10% when userId is 123', t => {
     const context = { environment: 'dev', userId: '123' };
     t.false(strategy.isEnabled(params, context));
 });
+
+test('should be disabled when stickiness=custom and contextField not specified', t => {
+    const strategy = new FlexibleRolloutStrategy();
+    const params = { rollout: '100', stickiness: 'custom', groupId: 'Demo' };
+    const context = {};
+    t.false(strategy.isEnabled(params, context));
+});
+
+test('should be disabled when stickiness=custom and contextField not found', t => {
+    const strategy = new FlexibleRolloutStrategy();
+    const params = {
+        rollout: '100',
+        stickiness: 'custom',
+        groupId: 'Demo',
+        contextField: 'customerId',
+    };
+    const context = {};
+    t.false(strategy.isEnabled(params, context));
+});
+
+test('should be enabled when stickiness=custom , customField=customerId and customerId=61', t => {
+    const strategy = new FlexibleRolloutStrategy();
+    const params = {
+        rollout: '100',
+        stickiness: 'custom',
+        groupId: 'Demo',
+        contextField: 'customerId',
+    };
+    const context = { customerId: 61 };
+    t.false(strategy.isEnabled(params, context));
+});

--- a/test/strategy/flexible-rollout-test.js
+++ b/test/strategy/flexible-rollout-test.js
@@ -47,7 +47,7 @@ test('should NOT be enabled for rollout=10% when userId is 123', t => {
     t.false(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when stickiness=customerId and contextField not found', t => {
+test('should be disabled when stickiness=customerId and customerId not found on context', t => {
     const strategy = new FlexibleRolloutStrategy();
     const params = {
         rollout: '100',


### PR DESCRIPTION
Stickiness on the flexible rollout strategy could be more generic.

The use case that I have:

- Our users are always part of an "organization"
- There are features that we want to rollout for all users of, let's say, 50% of organizations.

What I did:

- I added an additional stickiness type: `custom`.
- When `custom` is specified, a `contextField` must be specified as well.
- When `custom` is specified, we base stickiness based on the value of the `contextField` on the provided `context`.
- When `custom` is specified and `contextField` or it's value in the `context` is null or undefined, we return false and the flag is disabled.