### PR TITLE
chore: Bump all dev-dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,15 +5,9 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.json]
-indent_size = 2
-
-[*.yaml]
-indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
         "no-console": 0,
         "no-plusplus": "off",
         "max-len": ["error", {
-            "code": 140,
+            "code": 100,
             "ignoreTrailingComments": true,
             "ignoreUrls" :true
         }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,14 +1,21 @@
 {
     "extends": [
-        "finn",
-        "finn/node",
-        "finn/es-modules",
-        "finn-prettier"
+        "airbnb-typescript/base",
+        "prettier"
     ],
+    "plugins": ["prettier"],
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 8,
+        "project": ["./jsconfig.json", "./tsconfig.json"]
     },
     "rules": {
-        "no-console": 0
+        "no-console": 0,
+        "no-plusplus": "off",
+        "max-len": ["error", {
+            "code": 140,
+            "ignoreTrailingComments": true,
+            "ignoreUrls" :true
+        }],
+        "class-methods-use-this": "off"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 # 3.5.0
 
 -   fix: Replace deprecated request library with node-fetch
+-   chore: upgrade typescript to 4.1.3
+-   chore: upgrade sinon to 9.2.4
+-   chore: upgrade eslint to 7.19.0
+-   chore: migrate to eslint-config-airbnb
+-   chore: upgrade nock to 13.0.7
+-   chore: upgrade ava to 3.15.0
+-   chore: adopt eslint-config-airbnb-typescript
 
 # 3.4.0
 

--- a/examples/custom_repository.js
+++ b/examples/custom_repository.js
@@ -2,29 +2,31 @@ const { EventEmitter } = require('events');
 const { initialize, isEnabled } = require('../lib');
 
 class MyRepo extends EventEmitter {
-    constructor() {
-        super();
-        this.data = {
-            name: 'my-feature',
-            description: 'foo',
-            enabled: true,
-            strategies: [],
-            variants: [],
-        };
-    }
-    stop() {
-        return;
-    }
-    getToggle() {
-        return this.data;
-    }
+  constructor() {
+    super();
+    this.data = {
+      name: 'my-feature',
+      description: 'foo',
+      enabled: true,
+      strategies: [],
+      variants: [],
+    };
+  }
+
+  stop() {
+
+  }
+
+  getToggle() {
+    return this.data;
+  }
 }
 const repo = new MyRepo();
 const client = initialize({
-    appName: 'my-application',
-    url: 'not-needed',
-    disableMetrics: true,
-    repository: repo,
+  appName: 'my-application',
+  url: 'not-needed',
+  disableMetrics: true,
+  repository: repo,
 });
 repo.emit('ready');
 

--- a/examples/custom_strategy.js
+++ b/examples/custom_strategy.js
@@ -2,21 +2,21 @@ const { Strategy, initialize, isEnabled } = require('../lib');
 
 // Define custom strategy:
 class ActiveForUserWithEmailStrategy extends Strategy {
-    constructor() {
-        super('ActiveForUserWithEmail');
-    }
+  constructor() {
+    super('ActiveForUserWithEmail');
+  }
 
-    isEnabled(parameters, context) {
-        return parameters.emails.includes(context.email);
-    }
+  isEnabled(parameters, context) {
+    return parameters.emails.includes(context.email);
+  }
 }
 
 const client = initialize({
-    appName: 'my-application',
-    url: 'https://unleash-new-ui.herokuapp.com/api/',
-    refreshInterval: 5000,
-    metricsInterval: 5000,
-    strategies: [new ActiveForUserWithEmailStrategy()],
+  appName: 'my-application',
+  url: 'https://unleash-new-ui.herokuapp.com/api/',
+  refreshInterval: 5000,
+  metricsInterval: 5000,
+  strategies: [new ActiveForUserWithEmailStrategy()],
 });
 
 client.on('error', console.error);
@@ -25,9 +25,9 @@ client.on('warn', console.log);
 console.log('Fetching toggles from: https://unleash-new-ui.herokuapp.com', client);
 
 setInterval(() => {
-    console.log(`Test enabled: ${isEnabled('Test', { userId: '1234' })}`);
+  console.log(`Test enabled: ${isEnabled('Test', { userId: '1234' })}`);
 }, 1000);
 
 setInterval(() => {
-    console.log(`Test enabled: ${isEnabled('Test', { userId: '12' })}`);
+  console.log(`Test enabled: ${isEnabled('Test', { userId: '12' })}`);
 }, 1000);

--- a/examples/simple_usage.js
+++ b/examples/simple_usage.js
@@ -1,8 +1,8 @@
 const { initialize, isEnabled } = require('../lib');
 
 const client = initialize({
-    appName: 'my-application',
-    url: 'http://unleash.herokuapp.com/api/',
+  appName: 'my-application',
+  url: 'http://unleash.herokuapp.com/api/',
 });
 
 client.on('error', console.error);
@@ -11,5 +11,5 @@ client.on('warn', console.log);
 console.log('Fetching toggles from: http://unleash.herokuapp.com');
 
 setInterval(() => {
-    console.log(`featureX enabled: ${isEnabled('featureX')}`);
+  console.log(`featureX enabled: ${isEnabled('featureX')}`);
 }, 1000);

--- a/examples/test_all_toggles.js
+++ b/examples/test_all_toggles.js
@@ -1,13 +1,13 @@
 const { initialize, isEnabled, getFeatureToggleDefinitions } = require('../lib');
 
 const client = initialize({
-    appName: 'test-all-toggles',
-    url: 'https://unleash.herokuapp.com/api',
-    metricsInterval: 1000,
-    refreshInterval: 5000,
-    customHeaders: {
-        Authorization: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-    },
+  appName: 'test-all-toggles',
+  url: 'https://unleash.herokuapp.com/api',
+  metricsInterval: 1000,
+  refreshInterval: 5000,
+  customHeaders: {
+    Authorization: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
+  },
 });
 
 client.on('error', console.error);
@@ -18,7 +18,7 @@ client.on('changed', () => console.log('changed'));
 console.log('Fetching toggles from: https://unleash.herokuapp.com');
 
 setInterval(() => {
-    getFeatureToggleDefinitions().forEach(t => {
-        console.log(`${t.name}: ${isEnabled(t.name)}`);
-    });
+  getFeatureToggleDefinitions().forEach((t) => {
+    console.log(`${t.name}: ${isEnabled(t.name)}`);
+  });
 }, 1000);

--- a/examples/test_alot_of_users.js
+++ b/examples/test_alot_of_users.js
@@ -1,13 +1,13 @@
 const { initialize } = require('../lib');
 
 const client = initialize({
-    appName: 'test-all-toggles',
-    url: 'https://unleash.herokuapp.com/api',
-    metricsInterval: 1000,
-    refreshInterval: 5000,
-    customHeaders: {
-        Authorization: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-    },
+  appName: 'test-all-toggles',
+  url: 'https://unleash.herokuapp.com/api',
+  metricsInterval: 1000,
+  refreshInterval: 5000,
+  customHeaders: {
+    Authorization: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
+  },
 });
 
 client.on('error', console.error);
@@ -20,6 +20,6 @@ console.log('Fetching toggles from: https://unleash.herokuapp.com');
 const toggle = 'Demo';
 
 setInterval(() => {
-    const enabled = client.isEnabled(toggle, { userId: `${Math.random() * 10000}` });
-    console.log(`${toggle}: ${enabled}`);
+  const enabled = client.isEnabled(toggle, { userId: `${Math.random() * 10000}` });
+  console.log(`${toggle}: ${enabled}`);
 }, 100);

--- a/examples/variant.js
+++ b/examples/variant.js
@@ -1,8 +1,8 @@
 const { initialize, getVariant } = require('../lib');
 
 const client = initialize({
-    appName: 'my-application',
-    url: 'https://unleash.herokuapp.com/api/',
+  appName: 'my-application',
+  url: 'https://unleash.herokuapp.com/api/',
 });
 
 client.on('error', console.error);
@@ -11,5 +11,5 @@ client.on('warn', console.log);
 console.log('Fetching toggles from: http://unleash.herokuapp.com');
 
 setInterval(() => {
-    console.log(`Variant config`, getVariant('Test.variants', { userId: `${Math.random()}` }));
+  console.log('Variant config', getVariant('Test.variants', { userId: `${Math.random()}` }));
 }, 1000);

--- a/examples/with_constraints.js
+++ b/examples/with_constraints.js
@@ -1,10 +1,10 @@
 const { initialize, isEnabled } = require('../lib');
 
 const client = initialize({
-    appName: 'my-application',
-    environment: 'test',
-    refreshInterval: 1000,
-    url: 'http://unleash.herokuapp.com/api/',
+  appName: 'my-application',
+  environment: 'test',
+  refreshInterval: 1000,
+  url: 'http://unleash.herokuapp.com/api/',
 });
 
 client.on('error', console.error);
@@ -13,5 +13,5 @@ client.on('warn', console.log);
 console.log('Fetching toggles from: http://unleash.herokuapp.com');
 
 setInterval(() => {
-    console.log(`demo enabled: ${isEnabled('demo')}`);
+  console.log(`demo enabled: ${isEnabled('demo')}`);
 }, 1000);

--- a/examples/with_context.js
+++ b/examples/with_context.js
@@ -1,11 +1,11 @@
 const { initialize, isEnabled } = require('../lib');
 
 const client = initialize({
-    appName: 'my-application',
-    url: 'http://unleash.herokuapp.com/api/',
-    refreshInterval: 10000,
-    metricsInterval: 10000,
-    environment: 'production',
+  appName: 'my-application',
+  url: 'http://unleash.herokuapp.com/api/',
+  refreshInterval: 10000,
+  metricsInterval: 10000,
+  environment: 'production',
 });
 
 client.on('error', console.error);
@@ -14,11 +14,11 @@ client.on('warn', console.log);
 console.log('Fetching toggles from: http://unleash.herokuapp.com');
 
 setInterval(() => {
-    const context = {
-        userId: `${Math.random() * 100}`,
-        sessionId: Math.round(Math.random() * 1000),
-        remoteAddress: '127.0.0.1',
-    };
-    const toggleName = 'app.demo';
-    console.log(`${toggleName} enabled: ${isEnabled(toggleName, context)}`);
+  const context = {
+    userId: `${Math.random() * 100}`,
+    sessionId: Math.round(Math.random() * 1000),
+    remoteAddress: '127.0.0.1',
+  };
+  const toggleName = 'app.demo';
+  console.log(`${toggleName} enabled: ${isEnabled(toggleName, context)}`);
 }, 1000);

--- a/examples/with_instance.ts
+++ b/examples/with_instance.ts
@@ -1,38 +1,38 @@
-import { Unleash, Strategy } from '../lib/unleash';
 import * as express from 'express';
+import { Unleash, Strategy } from '../lib/unleash';
 
-let fixture = require('../test/fixtures/format-0.json');
+const fixture = require('../test/fixtures/format-0.json');
 
 const app = express();
 app.get('/', (req, res) => res.json(fixture));
 app.listen(1234);
 
 const strategies: Strategy[] = [
-    new Strategy('default', true),
-    new Strategy('ActiveForUserWithEmail', true),
-    new Strategy('default'),
+  new Strategy('default', true),
+  new Strategy('ActiveForUserWithEmail', true),
+  new Strategy('default'),
 ];
 
 const client = new Unleash({
-    appName: 'super-app',
-    backupPath: __dirname,
-    url: 'http://localhost:1234',
-    strategies,
+  appName: 'super-app',
+  backupPath: __dirname,
+  url: 'http://localhost:1234',
+  strategies,
 });
 
 client.on('error', console.error);
 client.on('warn', console.log);
 
 client.on('ready', () => {
-    setTimeout(() => {
-        console.log('featureX', client.isEnabled('featureX', {}));
-        console.log('featureY', client.isEnabled('featureY', {}));
-    }, 100);
+  setTimeout(() => {
+    console.log('featureX', client.isEnabled('featureX', {}));
+    console.log('featureY', client.isEnabled('featureY', {}));
+  }, 100);
 });
 
 console.log('featureX', client.isEnabled('featureX', {}));
 
 setInterval(() => {
-    console.log('featureX', client.isEnabled('featureX', {}));
-    console.log('featureY', client.isEnabled('featureY', {}));
+  console.log('featureX', client.isEnabled('featureX', {}));
+  console.log('featureY', client.isEnabled('featureY', {}));
 }, 5000);

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "examples"
   ],
   "devDependencies": {
+    "@ava/babel": "^1.0.1",
     "@types/ip": "^1.1.0",
     "@types/murmurhash3js": "^3.0.2",
-    "@types/nock": "^11.1.0",
     "@types/node": "^14.0.1",
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
@@ -96,12 +96,10 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "*.{ts,md,json}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "husky": {
@@ -110,6 +108,7 @@
     }
   },
   "ava": {
+    "babel": true,
     "require": [
       "esm"
     ],

--- a/package.json
+++ b/package.json
@@ -41,26 +41,31 @@
     "examples"
   ],
   "devDependencies": {
-    "@ava/babel": "^1.0.1",
     "@types/ip": "^1.1.0",
     "@types/murmurhash3js": "^3.0.2",
+    "@types/nock": "^11.1.0",
     "@types/node": "^14.0.1",
     "@types/node-fetch": "^2.5.8",
+    "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@unleash/client-specification": "^3.3.1",
     "ava": "^3.15.0",
-    "coveralls": "^3.0.3",
-    "cross-env": "^7.0.0",
-    "eslint": "^6.1.0",
-    "eslint-config-finn": "^3.0.0",
-    "eslint-config-finn-prettier": "^3.0.0",
-    "husky": "^4.2.1",
-    "lint-staged": "^10.0.3",
+    "coveralls": "^3.1.0",
+    "cross-env": "^7.0.3",
+    "eslint": "^7.19.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-config-airbnb-typescript": "^12.3.1",
+    "eslint-config-prettier": "^7.2.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prettier": "^3.3.1",
+    "esm": "^3.2.25",
+    "husky": "^4.3.8",
+    "lint-staged": "^10.5.4",
     "mkdirp": "^1.0.4",
     "nock": "^13.0.7",
     "nyc": "^15.1.0",
-    "prettier": "^1.17.1",
-    "sinon": "^9.0.0",
-    "typescript": "^3.8.2"
+    "prettier": "^2.2.1",
+    "sinon": "^9.2.4",
+    "typescript": "^4.1.3"
   },
   "nyc": {
     "lines": 95,
@@ -78,7 +83,7 @@
     "printWidth": 100,
     "proseWrap": "always",
     "singleQuote": true,
-    "tabWidth": 4,
+    "tabWidth": 2,
     "trailingComma": "all",
     "overrides": [
       {
@@ -90,8 +95,14 @@
     ]
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
-    "*.{ts,md,json}": "prettier --write"
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "*.{ts,md,json}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "husky": {
     "hooks": {
@@ -99,6 +110,13 @@
     }
   },
   "ava": {
-    "babel": true
+    "require": [
+      "esm"
+    ],
+    "files": [
+      "test/**/*",
+      "!test/*_custom_strategy.js",
+      "!test/fake_repo.js"
+    ]
   }
 }

--- a/scripts/build-details.js
+++ b/scripts/build-details.js
@@ -1,11 +1,13 @@
 const fs = require('fs');
-const { version } = require(`../package.json`);
+
+const { version } = require('../package.json');
+
 const name = 'unleash-client-node';
 
 const details = {
-    name,
-    version,
-    sdkVersion: `${name}:${version}`,
+  name,
+  version,
+  sdkVersion: `${name}:${version}`,
 };
 
 fs.writeFileSync('./src/details.json', JSON.stringify(details));

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,130 +6,122 @@ import { Variant, getDefaultVariant, VariantDefinition, selectVariant } from './
 import { Context } from './context';
 
 interface BooleanMap {
-    [key: string]: boolean;
+  [key: string]: boolean;
 }
 
 export default class UnleashClient extends EventEmitter {
-    private repository: RepositoryInterface;
-    private strategies: Strategy[];
-    private warned: BooleanMap;
+  private repository: RepositoryInterface;
 
-    constructor(repository: RepositoryInterface, strategies: Strategy[]) {
-        super();
-        this.repository = repository;
-        this.strategies = strategies || [];
-        this.warned = {};
+  private strategies: Strategy[];
 
-        this.strategies.forEach((strategy: Strategy) => {
-            if (
-                !strategy ||
-                !strategy.name ||
-                typeof strategy.name !== 'string' ||
-                !strategy.isEnabled ||
-                typeof strategy.isEnabled !== 'function'
-            ) {
-                throw new Error('Invalid strategy data / interface');
-            }
-        });
+  private warned: BooleanMap;
+
+  constructor(repository: RepositoryInterface, strategies: Strategy[]) {
+    super();
+    this.repository = repository;
+    this.strategies = strategies || [];
+    this.warned = {};
+
+    this.strategies.forEach((strategy: Strategy) => {
+      if (
+        !strategy ||
+        !strategy.name ||
+        typeof strategy.name !== 'string' ||
+        !strategy.isEnabled ||
+        typeof strategy.isEnabled !== 'function'
+      ) {
+        throw new Error('Invalid strategy data / interface');
+      }
+    });
+  }
+
+  private getStrategy(name: string): Strategy | undefined {
+    return this.strategies.find((strategy: Strategy): boolean => strategy.name === name);
+  }
+
+  warnOnce(missingStrategy: string, name: string, strategies: StrategyTransportInterface[]) {
+    if (!this.warned[missingStrategy + name]) {
+      this.warned[missingStrategy + name] = true;
+      this.emit(
+        'warn',
+        `Missing strategy "${missingStrategy}" for toggle "${name}". Ensure that "${strategies
+          .map(({ name: n }) => n)
+          .join(', ')}" are supported before using this toggle`,
+      );
+    }
+  }
+
+  isEnabled(name: string, context: Context, fallback: Function): boolean {
+    const feature = this.repository.getToggle(name);
+    return this.isFeatureEnabled(feature, context, fallback);
+  }
+
+  isFeatureEnabled(feature: FeatureInterface, context: Context, fallback: Function): boolean {
+    if (!feature) {
+      return fallback();
     }
 
-    private getStrategy(name: string): Strategy | undefined {
-        return this.strategies.find(
-            (strategy: Strategy): boolean => {
-                return strategy.name === name;
-            },
+    if (!feature || !feature.enabled) {
+      return false;
+    }
+
+    if (!Array.isArray(feature.strategies)) {
+      this.emit(
+        'error',
+        new Error(`Malformed feature, strategies not an array, is a ${typeof feature.strategies}`),
+      );
+      return false;
+    }
+
+    if (feature.strategies.length === 0) {
+      return feature.enabled;
+    }
+
+    return (
+      feature.strategies.length > 0 &&
+      feature.strategies.some((strategySelector): boolean => {
+        const strategy = this.getStrategy(strategySelector.name);
+        if (!strategy) {
+          this.warnOnce(strategySelector.name, feature.name, feature.strategies);
+          return false;
+        }
+        return strategy.isEnabledWithConstraints(
+          strategySelector.parameters,
+          context,
+          strategySelector.constraints,
         );
+      })
+    );
+  }
+
+  getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
+    const fallback = fallbackVariant || getDefaultVariant();
+    const feature = this.repository.getToggle(name);
+    if (
+      typeof feature === 'undefined' ||
+      !feature.variants ||
+      !Array.isArray(feature.variants) ||
+      feature.variants.length === 0
+    ) {
+      return fallback;
     }
 
-    warnOnce(missingStrategy: string, name: string, strategies: StrategyTransportInterface[]) {
-        if (!this.warned[missingStrategy + name]) {
-            this.warned[missingStrategy + name] = true;
-            this.emit(
-                'warn',
-                `Missing strategy "${missingStrategy}" for toggle "${name}". Ensure that "${strategies
-                    .map(({ name }) => name)
-                    .join(', ')}" are supported before using this toggle`,
-            );
-        }
+    const enabled = this.isFeatureEnabled(feature, context, () =>
+      fallbackVariant ? fallbackVariant.enabled : false,
+    );
+    if (!enabled) {
+      return fallback;
     }
 
-    isEnabled(name: string, context: Context, fallback: Function): boolean {
-        const feature = this.repository.getToggle(name);
-        return this.isFeatureEnabled(feature, context, fallback);
+    const variant: VariantDefinition | null = selectVariant(feature, context);
+    if (variant === null) {
+      return fallback;
     }
 
-    isFeatureEnabled(feature: FeatureInterface, context: Context, fallback: Function): boolean {
-        if (!feature) {
-            return fallback();
-        }
-
-        if (!feature || !feature.enabled) {
-            return false;
-        }
-
-        if (!Array.isArray(feature.strategies)) {
-            this.emit(
-                'error',
-                new Error(
-                    `Malformed feature, strategies not an array, is a ${typeof feature.strategies}`,
-                ),
-            );
-            return false;
-        }
-
-        if (feature.strategies.length === 0) {
-            return feature.enabled;
-        }
-
-        return (
-            feature.strategies.length > 0 &&
-            feature.strategies.some(
-                (strategySelector): boolean => {
-                    const strategy = this.getStrategy(strategySelector.name);
-                    if (!strategy) {
-                        this.warnOnce(strategySelector.name, feature.name, feature.strategies);
-                        return false;
-                    }
-                    return strategy.isEnabledWithConstraints(
-                        strategySelector.parameters,
-                        context,
-                        strategySelector.constraints,
-                    );
-                },
-            )
-        );
-    }
-
-    getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
-        if (!fallbackVariant) {
-            fallbackVariant = getDefaultVariant();
-        }
-        const feature = this.repository.getToggle(name);
-        if (
-            typeof feature === 'undefined' ||
-            !feature.variants ||
-            !Array.isArray(feature.variants) ||
-            feature.variants.length === 0
-        ) {
-            return fallbackVariant;
-        }
-
-        const enabled = this.isFeatureEnabled(feature, context, () =>
-            fallbackVariant ? fallbackVariant.enabled : false,
-        );
-        if (!enabled) {
-            return fallbackVariant;
-        }
-
-        const variant: VariantDefinition | null = selectVariant(feature, context);
-        if (variant === null) {
-            return fallbackVariant;
-        }
-
-        return {
-            name: variant.name,
-            payload: variant.payload,
-            enabled,
-        };
-    }
+    return {
+      name: variant.name,
+      payload: variant.payload,
+      enabled,
+    };
+  }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,13 +1,13 @@
 export interface Properties {
-    [key: string]: string | undefined | number;
+  [key: string]: string | undefined | number;
 }
 
 export interface Context {
-    [key: string]: string | undefined | number | Properties;
-    userId?: string;
-    sessionId?: string;
-    remoteAddress?: string;
-    environment?: string;
-    appName?: string;
-    properties?: Properties;
+  [key: string]: string | undefined | number | Properties;
+  userId?: string;
+  sessionId?: string;
+  remoteAddress?: string;
+  environment?: string;
+  appName?: string;
+  properties?: Properties;
 }

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -1,11 +1,12 @@
 import { StrategyTransportInterface } from './strategy';
+// eslint-disable-next-line import/no-cycle
 import { VariantDefinition } from './variant';
 
 export interface FeatureInterface {
-    name: string;
-    description?: string;
-    enabled: boolean;
-    stale: boolean;
-    strategies: StrategyTransportInterface[];
-    variants: VariantDefinition[];
+  name: string;
+  description?: string;
+  enabled: boolean;
+  stale: boolean;
+  strategies: StrategyTransportInterface[];
+  variants: VariantDefinition[];
 }

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,4 @@
+export interface CustomHeaders {
+  [key: string]: string;
+}
+export type CustomHeadersFunction = () => Promise<CustomHeaders>;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,25 +3,25 @@ import { Context } from './context';
 export type FallbackFunction = (name: string, context: Context) => boolean;
 
 export function createFallbackFunction(
-    name: string,
-    context: Context,
-    fallback?: FallbackFunction | boolean,
+  name: string,
+  context: Context,
+  fallback?: FallbackFunction | boolean,
 ): Function {
-    if (typeof fallback === 'function') {
-        return () => fallback(name, context);
-    } else if (typeof fallback === 'boolean') {
-        return () => fallback;
-    } else {
-        return () => false;
-    }
+  if (typeof fallback === 'function') {
+    return () => fallback(name, context);
+  }
+  if (typeof fallback === 'boolean') {
+    return () => fallback;
+  }
+  return () => false;
 }
 
 export function resolveContextValue(context: Context, field: string) {
-    if (context[field]) {
-        return context[field];
-    } else if (context.properties && context.properties[field]) {
-        return context.properties[field];
-    } else {
-        return undefined;
-    }
+  if (context[field]) {
+    return context[field];
+  }
+  if (context.properties && context.properties[field]) {
+    return context.properties[field];
+  }
+  return undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,45 +7,43 @@ export { Context, Variant, Unleash };
 
 let instance: Unleash | undefined;
 export function initialize(options: UnleashConfig): Unleash {
-    if (instance) {
-        instance.emit('warn', 'This global unleash instance is initialized multiple times.');
-    }
-    instance = new Unleash(options);
-    instance.on('error', () => {});
-    return instance;
+  if (instance) {
+    instance.emit('warn', 'This global unleash instance is initialized multiple times.');
+  }
+  instance = new Unleash(options);
+  instance.on('error', () => {});
+  return instance;
 }
 
 export function isEnabled(name: string, context: Context = {}, fallbackValue?: boolean): boolean {
-    return !!instance && instance.isEnabled(name, context, fallbackValue);
+  return !!instance && instance.isEnabled(name, context, fallbackValue);
 }
 
 export function destroy() {
-    return instance && instance.destroy();
+  return instance && instance.destroy();
 }
 
 export function getFeatureToggleDefinition(toggleName: string) {
-    return instance && instance.getFeatureToggleDefinition(toggleName);
+  return instance && instance.getFeatureToggleDefinition(toggleName);
 }
 
 export function getFeatureToggleDefinitions() {
-    return instance && instance.getFeatureToggleDefinitions();
+  return instance && instance.getFeatureToggleDefinitions();
 }
 
 export function getVariant(
-    name: string,
-    context: Context = {},
-    fallbackVariant?: Variant,
+  name: string,
+  context: Context = {},
+  fallbackVariant?: Variant,
 ): Variant {
-    if (!fallbackVariant) {
-        fallbackVariant = getDefaultVariant();
-    }
-    return instance ? instance.getVariant(name, context, fallbackVariant) : fallbackVariant;
+  const variant = fallbackVariant || getDefaultVariant();
+  return instance ? instance.getVariant(name, context, variant) : variant;
 }
 
 export function count(toggleName: string, enabled: boolean) {
-    return instance && instance.count(toggleName, enabled);
+  return instance && instance.count(toggleName, enabled);
 }
 
 export function countVariant(toggleName: string, variantName: string) {
-    return instance && instance.countVariant(toggleName, variantName);
+  return instance && instance.countVariant(toggleName, variantName);
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,265 +1,275 @@
 import { EventEmitter } from 'events';
 import { resolve } from 'url';
 import { post, Data } from './request';
-import { CustomHeaders, CustomHeadersFunction } from './unleash';
+import { CustomHeaders, CustomHeadersFunction } from './headers';
 import { sdkVersion } from './details.json';
 
 export interface MetricsOptions {
-    appName: string;
-    instanceId: string;
-    strategies: string[];
-    metricsInterval: number;
-    disableMetrics?: boolean;
-    bucketInterval?: number;
-    url: string;
-    headers?: CustomHeaders;
-    customHeadersFunction?: CustomHeadersFunction;
-    timeout?: number;
+  appName: string;
+  instanceId: string;
+  strategies: string[];
+  metricsInterval: number;
+  disableMetrics?: boolean;
+  bucketInterval?: number;
+  url: string;
+  headers?: CustomHeaders;
+  customHeadersFunction?: CustomHeadersFunction;
+  timeout?: number;
 }
 
 interface VariantBucket {
-    [s: string]: number;
+  [s: string]: number;
 }
 
 interface Bucket {
-    start: Date;
-    stop: Date | null;
-    toggles: { [s: string]: { yes: number; no: number; variants?: VariantBucket } };
+  start: Date;
+  stop: Date | null;
+  toggles: { [s: string]: { yes: number; no: number; variants?: VariantBucket } };
 }
 
 export default class Metrics extends EventEmitter {
-    private bucket: Bucket | undefined;
-    private appName: string;
-    private instanceId: string;
-    private sdkVersion: string;
-    private strategies: string[];
-    private metricsInterval: number;
-    private disabled: boolean;
-    private bucketInterval: number | undefined;
-    private url: string;
-    private timer: NodeJS.Timer | undefined;
-    private started: Date;
-    private headers?: CustomHeaders;
-    private customHeadersFunction?: CustomHeadersFunction;
-    private timeout?: number;
+  private bucket: Bucket | undefined;
 
-    constructor({
-        appName,
-        instanceId,
-        strategies,
-        metricsInterval = 0,
-        disableMetrics = false,
+  private appName: string;
+
+  private instanceId: string;
+
+  private sdkVersion: string;
+
+  private strategies: string[];
+
+  private metricsInterval: number;
+
+  private disabled: boolean;
+
+  private bucketInterval: number | undefined;
+
+  private url: string;
+
+  private timer: NodeJS.Timer | undefined;
+
+  private started: Date;
+
+  private headers?: CustomHeaders;
+
+  private customHeadersFunction?: CustomHeadersFunction;
+
+  private timeout?: number;
+
+  constructor({
+    appName,
+    instanceId,
+    strategies,
+    metricsInterval = 0,
+    disableMetrics = false,
+    url,
+    headers,
+    customHeadersFunction,
+    timeout,
+  }: MetricsOptions) {
+    super();
+    this.disabled = disableMetrics;
+    this.metricsInterval = metricsInterval;
+    this.appName = appName;
+    this.instanceId = instanceId;
+    this.sdkVersion = sdkVersion;
+    this.strategies = strategies;
+    this.url = url;
+    this.headers = headers;
+    this.customHeadersFunction = customHeadersFunction;
+    this.started = new Date();
+    this.timeout = timeout;
+    this.resetBucket();
+
+    if (typeof this.metricsInterval === 'number' && this.metricsInterval > 0) {
+      this.startTimer();
+      this.registerInstance();
+    }
+  }
+
+  private startTimer() {
+    if (this.disabled) {
+      return false;
+    }
+    this.timer = setTimeout(() => {
+      this.sendMetrics();
+    }, this.metricsInterval);
+
+    if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+    return true;
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      delete this.timer;
+    }
+    this.disabled = true;
+  }
+
+  async registerInstance(): Promise<boolean> {
+    if (this.disabled) {
+      return false;
+    }
+    const url = resolve(this.url, './client/register');
+    const payload = this.getClientData();
+
+    const headers = this.customHeadersFunction ? await this.customHeadersFunction() : this.headers;
+
+    try {
+      const res = await post({
         url,
+        json: payload,
+        appName: this.appName,
+        instanceId: this.instanceId,
         headers,
-        customHeadersFunction,
-        timeout,
-    }: MetricsOptions) {
-        super();
-        this.disabled = disableMetrics;
-        this.metricsInterval = metricsInterval;
-        this.appName = appName;
-        this.instanceId = instanceId;
-        this.sdkVersion = sdkVersion;
-        this.strategies = strategies;
-        this.url = url;
-        this.headers = headers;
-        this.customHeadersFunction = customHeadersFunction;
-        this.started = new Date();
-        this.timeout = timeout;
-        this.resetBucket();
+        timeout: this.timeout,
+      });
+      if (!res.ok) {
+        // status code outside 200 range
+        this.emit('warn', `${url} returning ${res.status}`, await res.text());
+      } else {
+        this.emit('registered', payload);
+      }
+    } catch (err) {
+      this.emit('error', err);
+    }
+    return true;
+  }
 
-        if (typeof this.metricsInterval === 'number' && this.metricsInterval > 0) {
-            this.startTimer();
-            this.registerInstance();
-        }
+  async sendMetrics(): Promise<boolean> {
+    /* istanbul ignore next if */
+    if (this.disabled) {
+      return false;
+    }
+    if (this.bucketIsEmpty()) {
+      this.resetBucket();
+      this.startTimer();
+      return true;
+    }
+    const url = resolve(this.url, './client/metrics');
+    const payload = this.getPayload();
+
+    const headers = this.customHeadersFunction ? await this.customHeadersFunction() : this.headers;
+
+    try {
+      const res = await post({
+        url,
+        json: payload,
+        appName: this.appName,
+        instanceId: this.instanceId,
+        headers,
+        timeout: this.timeout,
+      });
+      this.startTimer();
+      if (res.status === 404) {
+        this.emit('warn', `${url} returning 404, stopping metrics`);
+        this.stop();
+      }
+      if (!res.ok) {
+        this.emit('warn', `${url} returning ${res.status}`, await res.text());
+      } else {
+        this.emit('sent', payload);
+      }
+    } catch (err) {
+      this.emit('error', err);
+      this.startTimer();
+    }
+    return true;
+  }
+
+  assertBucket(name: string) {
+    if (this.disabled || !this.bucket) {
+      return false;
+    }
+    if (!this.bucket.toggles[name]) {
+      this.bucket.toggles[name] = {
+        yes: 0,
+        no: 0,
+      };
+    }
+    return true;
+  }
+
+  count(name: string, enabled: boolean): boolean {
+    if (this.disabled || !this.bucket) {
+      return false;
+    }
+    this.assertBucket(name);
+    this.bucket.toggles[name][enabled ? 'yes' : 'no']++;
+    this.emit('count', name, enabled);
+    return true;
+  }
+
+  countVariant(name: string, variantName: string) {
+    if (this.disabled || !this.bucket) {
+      return false;
+    }
+    this.assertBucket(name);
+    const { variants } = this.bucket.toggles[name];
+    if (typeof variants !== 'undefined') {
+      if (!variants[variantName]) {
+        variants[variantName] = 1;
+      } else {
+        variants[variantName]++;
+      }
+    } else {
+      this.bucket.toggles[name].variants = {
+        [variantName]: 1,
+      };
     }
 
-    private startTimer() {
-        if (this.disabled) {
-            return false;
-        }
-        this.timer = setTimeout(() => {
-            this.sendMetrics();
-        }, this.metricsInterval);
+    this.emit('countVariant', name, variantName);
+    return true;
+  }
 
-        if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
-            this.timer.unref();
-        }
-        return true;
+  private bucketIsEmpty() {
+    if (!this.bucket) {
+      return false;
     }
+    return Object.keys(this.bucket.toggles).length === 0;
+  }
 
-    stop() {
-        if (this.timer) {
-            clearInterval(this.timer);
-            delete this.timer;
-        }
-        this.disabled = true;
+  private resetBucket() {
+    const bucket: Bucket = {
+      start: new Date(),
+      stop: null,
+      toggles: {},
+    };
+    this.bucket = bucket;
+  }
+
+  private closeBucket() {
+    if (this.bucket) {
+      this.bucket.stop = new Date();
     }
+  }
 
-    async registerInstance(): Promise<boolean> {
-        if (this.disabled) {
-            return false;
-        }
-        const url = resolve(this.url, './client/register');
-        const payload = this.getClientData();
+  private getPayload(): Data {
+    this.closeBucket();
+    const payload = this.getMetricsData();
+    this.resetBucket();
+    return payload;
+  }
 
-        const headers = this.customHeadersFunction
-            ? await this.customHeadersFunction()
-            : this.headers;
+  getClientData(): Data {
+    return {
+      appName: this.appName,
+      instanceId: this.instanceId,
+      sdkVersion: this.sdkVersion,
+      strategies: this.strategies,
+      started: this.started,
+      interval: this.metricsInterval,
+    };
+  }
 
-        try {
-            const res = await post({
-                url,
-                json: payload,
-                appName: this.appName,
-                instanceId: this.instanceId,
-                headers,
-                timeout: this.timeout,
-            });
-            if (!res.ok) {
-                // status code outside 200 range
-                this.emit('warn', `${url} returning ${res.status}`, await res.text());
-            } else {
-                this.emit('registered', payload);
-            }
-        } catch (err) {
-            this.emit('error', err);
-        }
-        return true;
-    }
-
-    async sendMetrics(): Promise<boolean> {
-        /* istanbul ignore next if */
-        if (this.disabled) {
-            return false;
-        }
-        if (this.bucketIsEmpty()) {
-            this.resetBucket();
-            this.startTimer();
-            return true;
-        }
-        const url = resolve(this.url, './client/metrics');
-        const payload = this.getPayload();
-
-        const headers = this.customHeadersFunction
-            ? await this.customHeadersFunction()
-            : this.headers;
-
-        try {
-            const res = await post({
-                url,
-                json: payload,
-                appName: this.appName,
-                instanceId: this.instanceId,
-                headers,
-                timeout: this.timeout,
-            });
-            this.startTimer();
-            if (res.status === 404) {
-                this.emit('warn', `${url} returning 404, stopping metrics`);
-                this.stop();
-            }
-            if (!res.ok) {
-                this.emit('warn', `${url} returning ${res.status}`, await res.text());
-            } else {
-                this.emit('sent', payload);
-            }
-        } catch (err) {
-            this.emit('error', err);
-            this.startTimer();
-        }
-        return true;
-    }
-
-    assertBucket(name: string) {
-        if (this.disabled || !this.bucket) {
-            return false;
-        }
-        if (!this.bucket.toggles[name]) {
-            this.bucket.toggles[name] = {
-                yes: 0,
-                no: 0,
-            };
-        }
-    }
-
-    count(name: string, enabled: boolean): boolean {
-        if (this.disabled || !this.bucket) {
-            return false;
-        }
-        this.assertBucket(name);
-        this.bucket.toggles[name][enabled ? 'yes' : 'no']++;
-        this.emit('count', name, enabled);
-        return true;
-    }
-
-    countVariant(name: string, variantName: string) {
-        if (this.disabled || !this.bucket) {
-            return false;
-        }
-        this.assertBucket(name);
-        const variants = this.bucket.toggles[name].variants;
-        if (typeof variants !== 'undefined') {
-            if (!variants[variantName]) {
-                variants[variantName] = 1;
-            } else {
-                variants[variantName]++;
-            }
-        } else {
-            this.bucket.toggles[name].variants = {
-                [variantName]: 1,
-            };
-        }
-
-        this.emit('countVariant', name, variantName);
-        return true;
-    }
-
-    private bucketIsEmpty() {
-        if (!this.bucket) {
-            return false;
-        }
-        return Object.keys(this.bucket.toggles).length === 0;
-    }
-
-    private resetBucket() {
-        const bucket: Bucket = {
-            start: new Date(),
-            stop: null,
-            toggles: {},
-        };
-        this.bucket = bucket;
-    }
-
-    private closeBucket() {
-        if (this.bucket) {
-            this.bucket.stop = new Date();
-        }
-    }
-
-    private getPayload(): Data {
-        this.closeBucket();
-        const payload = this.getMetricsData();
-        this.resetBucket();
-        return payload;
-    }
-
-    getClientData(): Data {
-        return {
-            appName: this.appName,
-            instanceId: this.instanceId,
-            sdkVersion: this.sdkVersion,
-            strategies: this.strategies,
-            started: this.started,
-            interval: this.metricsInterval,
-        };
-    }
-
-    getMetricsData(): Data {
-        return {
-            appName: this.appName,
-            instanceId: this.instanceId,
-            bucket: this.bucket,
-        };
-    }
+  getMetricsData(): Data {
+    return {
+      appName: this.appName,
+      instanceId: this.instanceId,
+      bucket: this.bucket,
+    };
+  }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,174 +1,180 @@
 import { EventEmitter } from 'events';
+import { resolve } from 'url';
 import { Storage } from './storage';
 import { FeatureInterface } from './feature';
-import { resolve } from 'url';
 import { get } from './request';
-import { CustomHeaders, CustomHeadersFunction } from './unleash';
+import { CustomHeaders, CustomHeadersFunction } from './headers';
 
 export type StorageImpl = typeof Storage;
 
 export interface RepositoryInterface extends EventEmitter {
-    getToggle(name: string): FeatureInterface;
-    getToggles(): FeatureInterface[];
-    stop(): void;
+  getToggle(name: string): FeatureInterface;
+  getToggles(): FeatureInterface[];
+  stop(): void;
 }
 
 export interface RepositoryOptions {
-    backupPath: string;
-    url: string;
-    appName: string;
-    instanceId: string;
-    refreshInterval?: number;
-    StorageImpl?: StorageImpl;
-    timeout?: number;
-    headers?: CustomHeaders;
-    customHeadersFunction?: CustomHeadersFunction;
+  backupPath: string;
+  url: string;
+  appName: string;
+  instanceId: string;
+  refreshInterval?: number;
+  StorageImpl?: StorageImpl;
+  timeout?: number;
+  headers?: CustomHeaders;
+  customHeadersFunction?: CustomHeadersFunction;
 }
 
 export default class Repository extends EventEmitter implements EventEmitter {
-    private timer: NodeJS.Timer | undefined;
-    private url: string;
-    private storage: Storage;
-    private etag: string | undefined;
-    private appName: string;
-    private instanceId: string;
-    private refreshInterval?: number;
-    private headers?: CustomHeaders;
-    private customHeadersFunction?: CustomHeadersFunction;
-    private timeout?: number;
-    private stopped = false;
+  private timer: NodeJS.Timer | undefined;
 
-    constructor({
-        backupPath,
+  private url: string;
+
+  private storage: Storage;
+
+  private etag: string | undefined;
+
+  private appName: string;
+
+  private instanceId: string;
+
+  private refreshInterval?: number;
+
+  private headers?: CustomHeaders;
+
+  private customHeadersFunction?: CustomHeadersFunction;
+
+  private timeout?: number;
+
+  private stopped = false;
+
+  constructor({
+    backupPath,
+    url,
+    appName,
+    instanceId,
+    refreshInterval,
+    StorageImpl = Storage,
+    timeout,
+    headers,
+    customHeadersFunction,
+  }: RepositoryOptions) {
+    super();
+    this.url = url;
+    this.refreshInterval = refreshInterval;
+    this.instanceId = instanceId;
+    this.appName = appName;
+    this.headers = headers;
+    this.timeout = timeout;
+    this.customHeadersFunction = customHeadersFunction;
+
+    this.storage = new StorageImpl({ backupPath, appName });
+    this.storage.on('error', (err) => this.emit('error', err));
+    this.storage.on('ready', () => this.emit('ready'));
+
+    process.nextTick(() => this.fetch());
+  }
+
+  timedFetch() {
+    if (this.refreshInterval != null && this.refreshInterval > 0) {
+      this.timer = setTimeout(() => this.fetch(), this.refreshInterval);
+      if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
+        this.timer.unref();
+      }
+    }
+  }
+
+  validateFeature(feature: FeatureInterface) {
+    const errors: string[] = [];
+    if (!Array.isArray(feature.strategies)) {
+      errors.push(`feature.strategies should be an array, but was ${typeof feature.strategies}`);
+    }
+
+    if (feature.variants && !Array.isArray(feature.variants)) {
+      errors.push(`feature.variants should be an array, but was ${typeof feature.variants}`);
+    }
+
+    if (typeof feature.enabled !== 'boolean') {
+      errors.push(`feature.enabled should be an boolean, but was ${typeof feature.enabled}`);
+    }
+
+    if (errors.length > 0) {
+      const err = new Error(errors.join(', '));
+      this.emit('error', err);
+    }
+  }
+
+  async fetch() {
+    if (this.stopped) {
+      return;
+    }
+
+    try {
+      const url = resolve(this.url, './client/features');
+
+      const headers = this.customHeadersFunction
+        ? await this.customHeadersFunction()
+        : this.headers;
+
+      const res = await get({
         url,
-        appName,
-        instanceId,
-        refreshInterval,
-        StorageImpl = Storage,
-        timeout,
+        etag: this.etag,
+        appName: this.appName,
+        timeout: this.timeout,
+        instanceId: this.instanceId,
         headers,
-        customHeadersFunction,
-    }: RepositoryOptions) {
-        super();
-        this.url = url;
-        this.refreshInterval = refreshInterval;
-        this.instanceId = instanceId;
-        this.appName = appName;
-        this.headers = headers;
-        this.timeout = timeout;
-        this.customHeadersFunction = customHeadersFunction;
+      });
 
-        this.storage = new StorageImpl({ backupPath, appName });
-        this.storage.on('error', err => this.emit('error', err));
-        this.storage.on('ready', () => this.emit('ready'));
-
-        process.nextTick(() => this.fetch());
-    }
-
-    timedFetch() {
-        if (this.refreshInterval != null && this.refreshInterval > 0) {
-            this.timer = setTimeout(() => this.fetch(), this.refreshInterval);
-            if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
-                this.timer.unref();
-            }
-        }
-    }
-
-    validateFeature(feature: FeatureInterface) {
-        const errors: string[] = [];
-        if (!Array.isArray(feature.strategies)) {
-            errors.push(
-                `feature.strategies should be an array, but was ${typeof feature.strategies}`,
-            );
-        }
-
-        if (feature.variants && !Array.isArray(feature.variants)) {
-            errors.push(`feature.variants should be an array, but was ${typeof feature.variants}`);
-        }
-
-        if (typeof feature.enabled !== 'boolean') {
-            errors.push(`feature.enabled should be an boolean, but was ${typeof feature.enabled}`);
-        }
-
-        if (errors.length > 0) {
-            const err = new Error(errors.join(', '));
-            this.emit('error', err);
-        }
-    }
-
-    async fetch() {
-        if (this.stopped) {
-            return;
-        }
-
+      if (res.status === 304) {
+        // No new data
+        this.emit('unchanged');
+      } else if (!res.ok) {
+        this.emit('error', new Error(`Response was not statusCode 2XX, but was ${res.status}`));
+      } else {
         try {
-            const url = resolve(this.url, './client/features');
-
-            const headers = this.customHeadersFunction
-                ? await this.customHeadersFunction()
-                : this.headers;
-
-            const res = await get({
-                url,
-                etag: this.etag,
-                appName: this.appName,
-                timeout: this.timeout,
-                instanceId: this.instanceId,
-                headers,
-            });
-
-            if (res.status === 304) {
-                // No new data
-                this.emit('unchanged');
-            } else if (!res.ok) {
-                return this.emit(
-                    'error',
-                    new Error(`Response was not statusCode 2XX, but was ${res.status}`),
-                );
-            } else {
-                try {
-                    const data: any = await res.json();
-                    const obj = data.features.reduce(
-                        (o: { [s: string]: FeatureInterface }, feature: FeatureInterface) => {
-                            this.validateFeature(feature);
-                            o[feature.name] = feature;
-                            return o;
-                        },
-                        {} as { [s: string]: FeatureInterface },
-                    );
-                    this.storage.reset(obj);
-                    if (res.headers.get('etag') !== null) {
-                        this.etag = res.headers.get('etag') as string;
-                    } else {
-                        this.etag = undefined;
-                    }
-                    this.emit('changed', this.storage.getAll());
-                } catch (err) {
-                    this.emit('error', err);
-                }
-            }
+          const data: any = await res.json();
+          const obj = data.features.reduce(
+            (o: { [s: string]: FeatureInterface }, feature: FeatureInterface) => {
+              const a = { ...o };
+              this.validateFeature(feature);
+              a[feature.name] = feature;
+              return a;
+            },
+            {} as { [s: string]: FeatureInterface },
+          );
+          this.storage.reset(obj);
+          if (res.headers.get('etag') !== null) {
+            this.etag = res.headers.get('etag') as string;
+          } else {
+            this.etag = undefined;
+          }
+          this.emit('changed', this.storage.getAll());
         } catch (err) {
-            this.emit('error', err);
-        } finally {
-            this.timedFetch();
+          this.emit('error', err);
         }
+      }
+    } catch (err) {
+      this.emit('error', err);
+    } finally {
+      this.timedFetch();
     }
+  }
 
-    stop() {
-        this.stopped = true;
-        if (this.timer) {
-            clearTimeout(this.timer);
-        }
-        this.removeAllListeners();
-        this.storage.removeAllListeners();
+  stop() {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
     }
+    this.removeAllListeners();
+    this.storage.removeAllListeners();
+  }
 
-    getToggle(name: string): FeatureInterface {
-        return this.storage.get(name);
-    }
+  getToggle(name: string): FeatureInterface {
+    return this.storage.get(name);
+  }
 
-    getToggles(): FeatureInterface[] {
-        const toggles = this.storage.getAll();
-        return Object.keys(toggles).map(key => toggles[key]);
-    }
+  getToggles(): FeatureInterface[] {
+    const toggles = this.storage.getAll();
+    return Object.keys(toggles).map((key) => toggles[key]);
+  }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,77 +1,83 @@
-import { CustomHeaders } from './unleash';
-import fetch from 'node-fetch';
+import fetch, { Headers } from 'node-fetch';
 import * as http from 'http';
 import * as https from 'https';
 import { URL } from 'url';
+import { CustomHeaders } from './headers';
 
 export interface RequestOptions {
-    url: string;
-    timeout?: number;
-    headers?: CustomHeaders;
+  url: string;
+  timeout?: number;
+  headers?: CustomHeaders;
 }
 
 export interface GetRequestOptions extends RequestOptions {
-    etag?: string;
-    appName?: string;
-    instanceId?: string;
+  etag?: string;
+  appName?: string;
+  instanceId?: string;
 }
 
 export interface Data {
-    [key: string]: any;
+  [key: string]: any;
 }
 
 export interface PostRequestOptions extends RequestOptions {
-    json: Data;
-    appName?: string;
-    instanceId?: string;
+  json: Data;
+  appName?: string;
+  instanceId?: string;
 }
 const httpAgent = new http.Agent({
-    keepAlive: true,
-    keepAliveMsecs: 30 * 1000,
-    timeout: 10 * 1000,
+  keepAlive: true,
+  keepAliveMsecs: 30 * 1000,
+  timeout: 10 * 1000,
 });
 
 const httpsAgent = new https.Agent({
-    keepAlive: true,
-    keepAliveMsecs: 30 * 1000,
-    timeout: 10 * 1000,
+  keepAlive: true,
+  keepAliveMsecs: 30 * 1000,
+  timeout: 10 * 1000,
 });
 
 export const getAgent = (url: URL) => (url.protocol === 'https:' ? httpsAgent : httpAgent);
-export const post = ({ url, appName, timeout, instanceId, headers, json }: PostRequestOptions) => {
-    return fetch(url, {
-        timeout: timeout || 10000,
-        method: 'POST',
-        agent: getAgent,
-        headers: Object.assign(
-            {
-                'UNLEASH-APPNAME': appName,
-                'UNLEASH-INSTANCEID': instanceId,
-                'User-Agent': appName,
-                'Content-Type': 'application/json',
-            },
-            headers,
-        ),
-        body: JSON.stringify(json),
-    });
+export const buildHeaders = (
+  appName: string | undefined,
+  instanceId: string | undefined,
+  etag: string | undefined,
+  contentType: string | undefined,
+  custom: CustomHeaders | undefined,
+): Headers => {
+  const head = new Headers();
+  if (appName) {
+    head.append('UNLEASH-APPNAME', appName);
+    head.append('User-Agent', appName);
+  }
+  if (instanceId) {
+    head.append('UNLEASH-INSTANCEID', instanceId);
+  }
+  if (etag) {
+    head.append('If-None-Match', etag);
+  }
+  if (contentType) {
+    head.append('Content-Type', contentType);
+  }
+  if (custom) {
+    Object.keys(custom).forEach((k) => head.append(k, custom[k]));
+  }
+  return head;
 };
 
-export const get = ({ url, etag, appName, timeout, instanceId, headers }: GetRequestOptions) => {
-    const optHeaders = Object.assign(
-        {
-            'UNLEASH-APPNAME': appName,
-            'UNLEASH-INSTANCEID': instanceId,
-            'User-Agent': appName,
-        },
-        headers,
-    );
-    if (etag) {
-        optHeaders['If-None-Match'] = etag;
-    }
-    return fetch(url, {
-        method: 'GET',
-        timeout: timeout || 10000,
-        agent: url => (url.protocol === 'https:' ? httpsAgent : httpAgent),
-        headers: optHeaders,
-    });
-};
+export const post = ({ url, appName, timeout, instanceId, headers, json }: PostRequestOptions) =>
+  fetch(url, {
+    timeout: timeout || 10000,
+    method: 'POST',
+    agent: getAgent,
+    headers: buildHeaders(appName, instanceId, undefined, 'application/json', headers),
+    body: JSON.stringify(json),
+  });
+
+export const get = ({ url, etag, appName, timeout, instanceId, headers }: GetRequestOptions) =>
+  fetch(url, {
+    method: 'GET',
+    timeout: timeout || 10000,
+    agent: getAgent,
+    headers: buildHeaders(appName, instanceId, etag, undefined, headers),
+  });

--- a/src/strategy/application-hostname-strategy.ts
+++ b/src/strategy/application-hostname-strategy.ts
@@ -1,22 +1,22 @@
-import { Strategy } from './strategy';
 import { hostname } from 'os';
+import { Strategy } from './strategy';
 
-export class ApplicationHostnameStrategy extends Strategy {
-    private hostname: string;
+export default class ApplicationHostnameStrategy extends Strategy {
+  private hostname: string;
 
-    constructor() {
-        super('applicationHostname');
-        this.hostname = (process.env.HOSTNAME || hostname() || 'undefined').toLowerCase();
+  constructor() {
+    super('applicationHostname');
+    this.hostname = (process.env.HOSTNAME || hostname() || 'undefined').toLowerCase();
+  }
+
+  isEnabled(parameters: any) {
+    if (!parameters.hostNames) {
+      return false;
     }
 
-    isEnabled(parameters: any) {
-        if (!parameters.hostNames) {
-            return false;
-        }
-
-        return parameters.hostNames
-            .toLowerCase()
-            .split(/\s*,\s*/)
-            .includes(this.hostname);
-    }
+    return parameters.hostNames
+      .toLowerCase()
+      .split(/\s*,\s*/)
+      .includes(this.hostname);
+  }
 }

--- a/src/strategy/default-strategy.ts
+++ b/src/strategy/default-strategy.ts
@@ -1,11 +1,11 @@
 import { Strategy } from './strategy';
 
-export class DefaultStrategy extends Strategy {
-    constructor() {
-        super('default');
-    }
+export default class DefaultStrategy extends Strategy {
+  constructor() {
+    super('default');
+  }
 
-    isEnabled() {
-        return true;
-    }
+  isEnabled() {
+    return true;
+  }
 }

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -1,45 +1,44 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
-import { normalizedValue } from './util';
+import normalizedValue from './util';
 import { resolveContextValue } from '../helpers';
 
 const STICKINESS = {
-    default: 'default',
-    random: 'random',
+  default: 'default',
+  random: 'random',
 };
 
-export class FlexibleRolloutStrategy extends Strategy {
-    private randomGenerator: Function = () => Math.round(Math.random() * 100) + 1 + '';
+export default class FlexibleRolloutStrategy extends Strategy {
+  private randomGenerator: Function = () => `${Math.round(Math.random() * 100) + 1}`;
 
-    constructor(radnomGenerator?: Function) {
-        super('flexibleRollout');
-        if (radnomGenerator) {
-            this.randomGenerator = radnomGenerator;
-        }
+  constructor(radnomGenerator?: Function) {
+    super('flexibleRollout');
+    if (radnomGenerator) {
+      this.randomGenerator = radnomGenerator;
     }
+  }
 
-    resolveStickiness(stickiness: string, context: Context): any {
-        switch (stickiness) {
-            case STICKINESS.default:
-                return context.userId || context.sessionId || this.randomGenerator();
-            case STICKINESS.random:
-                return this.randomGenerator();
-            default:
-                return resolveContextValue(context, stickiness);
-        }
+  resolveStickiness(stickiness: string, context: Context): any {
+    switch (stickiness) {
+      case STICKINESS.default:
+        return context.userId || context.sessionId || this.randomGenerator();
+      case STICKINESS.random:
+        return this.randomGenerator();
+      default:
+        return resolveContextValue(context, stickiness);
     }
+  }
 
-    isEnabled(parameters: any, context: Context) {
-        const groupId = parameters.groupId || context.featureToggle || '';
-        const percentage = Number(parameters.rollout);
-        const stickiness: string = parameters.stickiness || STICKINESS.default;
-        const stickinessId = this.resolveStickiness(stickiness, context);
+  isEnabled(parameters: any, context: Context) {
+    const groupId = parameters.groupId || context.featureToggle || '';
+    const percentage = Number(parameters.rollout);
+    const stickiness: string = parameters.stickiness || STICKINESS.default;
+    const stickinessId = this.resolveStickiness(stickiness, context);
 
-        if (!stickinessId) {
-            return false;
-        } else {
-            const normalizedUserId = normalizedValue(stickinessId, groupId);
-            return percentage > 0 && normalizedUserId <= percentage;
-        }
+    if (!stickinessId) {
+      return false;
     }
+    const normalizedUserId = normalizedValue(stickinessId, groupId);
+    return percentage > 0 && normalizedUserId <= percentage;
+  }
 }

--- a/src/strategy/gradual-rollout-random.ts
+++ b/src/strategy/gradual-rollout-random.ts
@@ -1,17 +1,18 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
 
-export class GradualRolloutRandomStrategy extends Strategy {
-    private randomGenerator: Function = () => Math.floor(Math.random() * 100) + 1;
+export default class GradualRolloutRandomStrategy extends Strategy {
+  private randomGenerator: Function = () => Math.floor(Math.random() * 100) + 1;
 
-    constructor(randomGenerator?: Function) {
-        super('gradualRolloutRandom');
-        this.randomGenerator = randomGenerator || this.randomGenerator;
-    }
+  constructor(randomGenerator?: Function) {
+    super('gradualRolloutRandom');
+    this.randomGenerator = randomGenerator || this.randomGenerator;
+  }
 
-    isEnabled(parameters: any, context: Context) {
-        const percentage: number = Number(parameters.percentage);
-        const random: number = this.randomGenerator();
-        return percentage >= random;
-    }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isEnabled(parameters: any, context: Context) {
+    const percentage: number = Number(parameters.percentage);
+    const random: number = this.randomGenerator();
+    return percentage >= random;
+  }
 }

--- a/src/strategy/gradual-rollout-session-id.ts
+++ b/src/strategy/gradual-rollout-session-id.ts
@@ -1,23 +1,23 @@
 import { Strategy } from './strategy';
-import { normalizedValue } from './util';
+import normalizedValue from './util';
 import { Context } from '../context';
 
-export class GradualRolloutSessionIdStrategy extends Strategy {
-    constructor() {
-        super('gradualRolloutSessionId');
+export default class GradualRolloutSessionIdStrategy extends Strategy {
+  constructor() {
+    super('gradualRolloutSessionId');
+  }
+
+  isEnabled(parameters: any, context: Context) {
+    const { sessionId } = context;
+    if (!sessionId) {
+      return false;
     }
 
-    isEnabled(parameters: any, context: Context) {
-        const sessionId = context.sessionId;
-        if (!sessionId) {
-            return false;
-        }
+    const percentage = Number(parameters.percentage);
+    const groupId = parameters.groupId || '';
 
-        const percentage = Number(parameters.percentage);
-        const groupId = parameters.groupId || '';
+    const normalizedId = normalizedValue(sessionId, groupId);
 
-        const normalizedId = normalizedValue(sessionId, groupId);
-
-        return percentage > 0 && normalizedId <= percentage;
-    }
+    return percentage > 0 && normalizedId <= percentage;
+  }
 }

--- a/src/strategy/gradual-rollout-user-id.ts
+++ b/src/strategy/gradual-rollout-user-id.ts
@@ -1,23 +1,23 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
-import { normalizedValue } from './util';
+import normalizedValue from './util';
 
-export class GradualRolloutUserIdStrategy extends Strategy {
-    constructor() {
-        super('gradualRolloutUserId');
+export default class GradualRolloutUserIdStrategy extends Strategy {
+  constructor() {
+    super('gradualRolloutUserId');
+  }
+
+  isEnabled(parameters: any, context: Context) {
+    const { userId } = context;
+    if (!userId) {
+      return false;
     }
 
-    isEnabled(parameters: any, context: Context) {
-        const userId = context.userId;
-        if (!userId) {
-            return false;
-        }
+    const percentage = Number(parameters.percentage);
+    const groupId = parameters.groupId || '';
 
-        const percentage = Number(parameters.percentage);
-        const groupId = parameters.groupId || '';
+    const normalizedUserId = normalizedValue(userId, groupId);
 
-        const normalizedUserId = normalizedValue(userId, groupId);
-
-        return percentage > 0 && normalizedUserId <= percentage;
-    }
+    return percentage > 0 && normalizedUserId <= percentage;
+  }
 }

--- a/src/strategy/index.ts
+++ b/src/strategy/index.ts
@@ -1,22 +1,23 @@
-import { DefaultStrategy } from './default-strategy';
-import { ApplicationHostnameStrategy } from './application-hostname-strategy';
-import { GradualRolloutRandomStrategy } from './gradual-rollout-random';
-import { GradualRolloutUserIdStrategy } from './gradual-rollout-user-id';
-import { GradualRolloutSessionIdStrategy } from './gradual-rollout-session-id';
-import { UserWithIdStrategy } from './user-with-id-strategy';
-import { RemoteAddressStrategy } from './remote-addresss-strategy';
-import { FlexibleRolloutStrategy } from './flexible-rollout-strategy';
+import DefaultStrategy from './default-strategy';
+import ApplicationHostnameStrategy from './application-hostname-strategy';
+import GradualRolloutRandomStrategy from './gradual-rollout-random';
+import GradualRolloutUserIdStrategy from './gradual-rollout-user-id';
+import GradualRolloutSessionIdStrategy from './gradual-rollout-session-id';
+import UserWithIdStrategy from './user-with-id-strategy';
+import RemoteAddressStrategy from './remote-addresss-strategy';
+import FlexibleRolloutStrategy from './flexible-rollout-strategy';
 import { Strategy } from './strategy';
+
 export { Strategy } from './strategy';
 export { StrategyTransportInterface } from './strategy';
 
 export const defaultStrategies: Array<Strategy> = [
-    new DefaultStrategy(),
-    new ApplicationHostnameStrategy(),
-    new GradualRolloutRandomStrategy(),
-    new GradualRolloutUserIdStrategy(),
-    new GradualRolloutSessionIdStrategy(),
-    new UserWithIdStrategy(),
-    new RemoteAddressStrategy(),
-    new FlexibleRolloutStrategy(),
+  new DefaultStrategy(),
+  new ApplicationHostnameStrategy(),
+  new GradualRolloutRandomStrategy(),
+  new GradualRolloutUserIdStrategy(),
+  new GradualRolloutSessionIdStrategy(),
+  new UserWithIdStrategy(),
+  new RemoteAddressStrategy(),
+  new FlexibleRolloutStrategy(),
 ];

--- a/src/strategy/remote-addresss-strategy.ts
+++ b/src/strategy/remote-addresss-strategy.ts
@@ -1,29 +1,31 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
+
 const ip = require('ip');
 
-export class RemoteAddressStrategy extends Strategy {
-    constructor() {
-        super('remoteAddress');
-    }
+export default class RemoteAddressStrategy extends Strategy {
+  constructor() {
+    super('remoteAddress');
+  }
 
-    isEnabled(parameters: any, context: Context) {
-        if (!parameters.IPs) {
-            return false;
+  isEnabled(parameters: any, context: Context) {
+    if (!parameters.IPs) {
+      return false;
+    }
+    return parameters.IPs.split(/\s*,\s*/).some(
+      (range: string): Boolean => {
+        if (range === context.remoteAddress) {
+          return true;
         }
-        for (const range of parameters.IPs.split(/\s*,\s*/)) {
-            try {
-                if (range === context.remoteAddress) {
-                    return true;
-                } else if (!ip.isV6Format(range)) {
-                    if (ip.cidrSubnet(range).contains(context.remoteAddress)) {
-                        return true;
-                    }
-                }
-            } catch (e) {
-                continue;
-            }
+        if (!ip.isV6Format(range)) {
+          try {
+            return ip.cidrSubnet(range).contains(context.remoteAddress);
+          } catch (err) {
+            return false;
+          }
         }
         return false;
-    }
+      },
+    );
+  }
 }

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -1,51 +1,53 @@
 import { Context } from '../context';
 import { resolveContextValue } from '../helpers';
 
-export class Strategy {
-    public name: string;
-    private returnValue: boolean;
-
-    constructor(name: string, returnValue: boolean = false) {
-        this.name = name || 'unknown';
-        this.returnValue = returnValue;
-    }
-
-    checkConstraint(constraint: Constraint, context: Context) {
-        const field = constraint.contextName;
-        const contextValue = resolveContextValue(context, field);
-        const isIn = constraint.values.some(val => val.trim() === contextValue);
-        return constraint.operator === Operator.IN ? isIn : !isIn;
-    }
-
-    checkConstraints(context: Context, constraints?: Constraint[]) {
-        if (!constraints || constraints.length === 0) {
-            return true;
-        }
-        return constraints.every(constraint => this.checkConstraint(constraint, context));
-    }
-
-    isEnabled(parameters: any, context: Context): boolean {
-        return this.returnValue;
-    }
-
-    isEnabledWithConstraints(parameters: any, context: Context, constraints: Constraint[] = []) {
-        return this.checkConstraints(context, constraints) && this.isEnabled(parameters, context);
-    }
-}
-
 export interface StrategyTransportInterface {
-    name: string;
-    parameters: any;
-    constraints: Constraint[];
+  name: string;
+  parameters: any;
+  constraints: Constraint[];
 }
 
 export interface Constraint {
-    contextName: string;
-    operator: Operator;
-    values: string[];
+  contextName: string;
+  operator: Operator;
+  values: string[];
 }
 
 export enum Operator {
-    IN = <any>'IN',
-    NOT_IN = <any>'NOT_IN',
+  IN = <any>'IN',
+  NOT_IN = <any>'NOT_IN',
+}
+
+export class Strategy {
+  public name: string;
+
+  private returnValue: boolean;
+
+  constructor(name: string, returnValue: boolean = false) {
+    this.name = name || 'unknown';
+    this.returnValue = returnValue;
+  }
+
+  checkConstraint(constraint: Constraint, context: Context) {
+    const field = constraint.contextName;
+    const contextValue = resolveContextValue(context, field);
+    const isIn = constraint.values.some((val) => val.trim() === contextValue);
+    return constraint.operator === Operator.IN ? isIn : !isIn;
+  }
+
+  checkConstraints(context: Context, constraints?: Constraint[]) {
+    if (!constraints || constraints.length === 0) {
+      return true;
+    }
+    return constraints.every((constraint) => this.checkConstraint(constraint, context));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isEnabled(parameters: any, context: Context): boolean {
+    return this.returnValue;
+  }
+
+  isEnabledWithConstraints(parameters: any, context: Context, constraints: Constraint[] = []) {
+    return this.checkConstraints(context, constraints) && this.isEnabled(parameters, context);
+  }
 }

--- a/src/strategy/user-with-id-strategy.ts
+++ b/src/strategy/user-with-id-strategy.ts
@@ -1,13 +1,13 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
 
-export class UserWithIdStrategy extends Strategy {
-    constructor() {
-        super('userWithId');
-    }
+export default class UserWithIdStrategy extends Strategy {
+  constructor() {
+    super('userWithId');
+  }
 
-    isEnabled(parameters: any, context: Context) {
-        const userIdList = parameters.userIds.split(/\s*,\s*/);
-        return userIdList.includes(context.userId);
-    }
+  isEnabled(parameters: any, context: Context) {
+    const userIdList = parameters.userIds.split(/\s*,\s*/);
+    return userIdList.includes(context.userId);
+  }
 }

--- a/src/strategy/util.ts
+++ b/src/strategy/util.ts
@@ -1,5 +1,5 @@
 import * as murmurHash3 from 'murmurhash3js';
 
-export function normalizedValue(id: string, groupId: string, normalizer = 100): number {
-    return (murmurHash3.x86.hash32(`${groupId}:${id}`) % normalizer) + 1;
+export default function normalizedValue(id: string, groupId: string, normalizer = 100): number {
+  return (murmurHash3.x86.hash32(`${groupId}:${id}`) % normalizer) + 1;
 }

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -1,242 +1,244 @@
+import { tmpdir, userInfo, hostname } from 'os';
+import { EventEmitter } from 'events';
 import Client from './client';
 import Repository, { RepositoryInterface } from './repository';
 import Metrics from './metrics';
+import { CustomHeaders, CustomHeadersFunction } from './headers';
 import { Context } from './context';
 import { Strategy, defaultStrategies } from './strategy';
-export { Strategy };
-import { tmpdir } from 'os';
-import { EventEmitter } from 'events';
-import { userInfo, hostname } from 'os';
+
 import { FeatureInterface } from './feature';
 import { Variant, getDefaultVariant } from './variant';
 import { FallbackFunction, createFallbackFunction } from './helpers';
 
+export { Strategy };
+
 const BACKUP_PATH: string = tmpdir();
 
-export interface CustomHeaders {
-    [key: string]: string;
-}
-
-export type CustomHeadersFunction = () => Promise<CustomHeaders>;
-
 export interface UnleashConfig {
-    appName: string;
-    environment?: string;
-    instanceId?: string;
-    url: string;
-    refreshInterval?: number;
-    metricsInterval?: number;
-    disableMetrics?: boolean;
-    backupPath?: string;
-    strategies?: Strategy[];
-    customHeaders?: CustomHeaders;
-    customHeadersFunction?: CustomHeadersFunction;
-    timeout?: number;
-    repository?: RepositoryInterface;
+  appName: string;
+  environment?: string;
+  instanceId?: string;
+  url: string;
+  refreshInterval?: number;
+  metricsInterval?: number;
+  disableMetrics?: boolean;
+  backupPath?: string;
+  strategies?: Strategy[];
+  customHeaders?: CustomHeaders;
+  customHeadersFunction?: CustomHeadersFunction;
+  timeout?: number;
+  repository?: RepositoryInterface;
 }
 
 export interface StaticContext {
-    appName: string;
-    environment: string;
+  appName: string;
+  environment: string;
 }
 
 export class Unleash extends EventEmitter {
-    private repository: RepositoryInterface;
-    private client: Client | undefined;
-    private metrics: Metrics;
-    private staticContext: StaticContext;
+  private repository: RepositoryInterface;
 
-    constructor({
+  private client: Client | undefined;
+
+  private metrics: Metrics;
+
+  private staticContext: StaticContext;
+
+  constructor({
+    appName,
+    environment = 'default',
+    instanceId,
+    url,
+    refreshInterval = 15 * 1000,
+    metricsInterval = 60 * 1000,
+    disableMetrics = false,
+    backupPath = BACKUP_PATH,
+    strategies = [],
+    repository,
+    customHeaders,
+    customHeadersFunction,
+    timeout,
+  }: UnleashConfig) {
+    super();
+
+    if (!url) {
+      throw new Error('Unleash server URL missing');
+    }
+    let unleashUrl = url;
+    if (unleashUrl.endsWith('/features')) {
+      const oldUrl = unleashUrl;
+      process.nextTick(() =>
+        this.emit(
+          'warn',
+          `Unleash server URL "${oldUrl}" should no longer link directly to /features`,
+        ),
+      );
+      unleashUrl = unleashUrl.replace(/\/features$/, '');
+    }
+
+    if (!unleashUrl.endsWith('/')) {
+      unleashUrl += '/';
+    }
+
+    if (!appName) {
+      throw new Error('Unleash client appName missing');
+    }
+
+    let unleashInstanceId = instanceId;
+    if (!unleashInstanceId) {
+      let info;
+      try {
+        info = userInfo();
+      } catch (e) {
+        // unable to read info;
+      }
+
+      const prefix = info
+        ? info.username
+        : `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
+      unleashInstanceId = `${prefix}-${hostname()}`;
+    }
+
+    this.staticContext = { appName, environment };
+
+    this.repository =
+      repository ||
+      new Repository({
+        backupPath,
+        url: unleashUrl,
         appName,
-        environment = 'default',
-        instanceId,
-        url,
-        refreshInterval = 15 * 1000,
-        metricsInterval = 60 * 1000,
-        disableMetrics = false,
-        backupPath = BACKUP_PATH,
-        strategies = [],
-        repository,
-        customHeaders,
+        instanceId: unleashInstanceId,
+        refreshInterval,
+        headers: customHeaders,
         customHeadersFunction,
         timeout,
-    }: UnleashConfig) {
-        super();
+      });
 
-        if (!url) {
-            throw new Error('Unleash server URL missing');
-        }
+    const strats = defaultStrategies.concat(strategies);
 
-        if (url.endsWith('/features')) {
-            const oldUrl = url;
-            process.nextTick(() =>
-                this.emit(
-                    'warn',
-                    `Unleash server URL "${oldUrl}" should no longer link directly to /features`,
-                ),
-            );
-            url = url.replace(/\/features$/, '');
-        }
+    this.repository.on('ready', () => {
+      this.client = new Client(this.repository, strats);
+      this.client.on('error', (err) => this.emit('error', err));
+      this.client.on('warn', (msg) => this.emit('warn', msg));
+      process.nextTick(() => {
+        this.emit('ready');
+      });
+    });
 
-        if (!url.endsWith('/')) {
-            url += '/';
-        }
+    this.repository.on('error', (err) => {
+      // eslint-disable-next-line no-param-reassign
+      err.message = `Unleash Repository error: ${err.message}`;
+      this.emit('error', err);
+    });
 
-        if (!appName) {
-            throw new Error('Unleash client appName missing');
-        }
+    this.repository.on('warn', (msg) => {
+      this.emit('warn', msg);
+    });
 
-        if (!instanceId) {
-            let info;
-            try {
-                info = userInfo();
-            } catch (e) {
-                //unable to read info;
-            }
+    this.repository.on('unchanged', () => {
+      this.emit('unchanged');
+    });
 
-            const prefix = info
-                ? info.username
-                : `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
-            instanceId = `${prefix}-${hostname()}`;
-        }
+    this.repository.on('changed', (data) => {
+      this.emit('changed', data);
+    });
 
-        this.staticContext = { appName, environment };
+    this.metrics = new Metrics({
+      disableMetrics,
+      appName,
+      instanceId: unleashInstanceId,
+      strategies: strats.map((strategy: Strategy) => strategy.name),
+      metricsInterval,
+      url,
+      headers: customHeaders,
+      customHeadersFunction,
+      timeout,
+    });
 
-        this.repository =
-            repository ||
-            new Repository({
-                backupPath,
-                url,
-                appName,
-                instanceId,
-                refreshInterval,
-                headers: customHeaders,
-                customHeadersFunction,
-                timeout,
-            });
+    this.metrics.on('error', (err) => {
+      // eslint-disable-next-line no-param-reassign
+      err.message = `Unleash Metrics error: ${err.message}`;
+      this.emit('error', err);
+    });
 
-        strategies = defaultStrategies.concat(strategies);
+    this.metrics.on('warn', (msg) => {
+      this.emit('warn', msg);
+    });
 
-        this.repository.on('ready', () => {
-            this.client = new Client(this.repository, strategies);
-            this.client.on('error', err => this.emit('error', err));
-            this.client.on('warn', msg => this.emit('warn', msg));
-            process.nextTick(() => {
-                this.emit('ready');
-            });
-        });
+    this.metrics.on('count', (name, enabled) => {
+      this.emit('count', name, enabled);
+    });
 
-        this.repository.on('error', err => {
-            err.message = `Unleash Repository error: ${err.message}`;
-            this.emit('error', err);
-        });
+    this.metrics.on('sent', (payload) => {
+      this.emit('sent', payload);
+    });
 
-        this.repository.on('warn', msg => {
-            this.emit('warn', msg);
-        });
+    this.metrics.on('registered', (payload) => {
+      this.emit('registered', payload);
+    });
+  }
 
-        this.repository.on('unchanged', () => {
-            this.emit('unchanged');
-        });
+  destroy() {
+    this.repository.stop();
+    this.metrics.stop();
+    this.client = undefined;
+  }
 
-        this.repository.on('changed', data => {
-            this.emit('changed', data);
-        });
+  isEnabled(name: string, context: Context, fallbackFunction?: FallbackFunction): boolean;
+  isEnabled(name: string, context: Context, fallbackValue?: boolean): boolean;
+  isEnabled(name: string, context: Context, fallback?: FallbackFunction | boolean): boolean {
+    const enhancedContext = { ...this.staticContext, ...context };
+    const fallbackFunc = createFallbackFunction(name, enhancedContext, fallback);
 
-        this.metrics = new Metrics({
-            disableMetrics,
-            appName,
-            instanceId,
-            strategies: strategies.map((strategy: Strategy) => strategy.name),
-            metricsInterval,
-            url,
-            headers: customHeaders,
-            customHeadersFunction,
-            timeout,
-        });
+    let result;
+    if (this.client !== undefined) {
+      result = this.client.isEnabled(name, enhancedContext, fallbackFunc);
+    } else {
+      result = fallbackFunc();
+      this.emit(
+        'warn',
+        `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${result}`,
+      );
+    }
+    this.count(name, result);
+    return result;
+  }
 
-        this.metrics.on('error', err => {
-            err.message = `Unleash Metrics error: ${err.message}`;
-            this.emit('error', err);
-        });
-
-        this.metrics.on('warn', msg => {
-            this.emit('warn', msg);
-        });
-
-        this.metrics.on('count', (name, enabled) => {
-            this.emit('count', name, enabled);
-        });
-
-        this.metrics.on('sent', payload => {
-            this.emit('sent', payload);
-        });
-
-        this.metrics.on('registered', payload => {
-            this.emit('registered', payload);
-        });
+  getVariant(name: string, context: any, fallbackVariant?: Variant): Variant {
+    const enhancedContext = { ...this.staticContext, ...context };
+    let result;
+    if (this.client !== undefined) {
+      result = this.client.getVariant(name, enhancedContext, fallbackVariant);
+    } else {
+      result = typeof fallbackVariant !== 'undefined' ? fallbackVariant : getDefaultVariant();
+      this.emit(
+        'warn',
+        `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${result}`,
+      );
+    }
+    if (result.name) {
+      this.countVariant(name, result.name);
+    } else {
+      this.count(name, result.enabled);
     }
 
-    destroy() {
-        this.repository.stop();
-        this.metrics.stop();
-        this.client = undefined;
-    }
+    return result;
+  }
 
-    isEnabled(name: string, context: Context, fallbackFunction?: FallbackFunction): boolean;
-    isEnabled(name: string, context: Context, fallbackValue?: boolean): boolean;
-    isEnabled(name: string, context: Context, fallback?: FallbackFunction | boolean): boolean {
-        const enhancedContext = Object.assign({}, this.staticContext, context);
-        const fallbackFunc = createFallbackFunction(name, enhancedContext, fallback);
+  getFeatureToggleDefinition(toggleName: string): FeatureInterface {
+    return this.repository.getToggle(toggleName);
+  }
 
-        let result;
-        if (this.client !== undefined) {
-            result = this.client.isEnabled(name, enhancedContext, fallbackFunc);
-        } else {
-            result = fallbackFunc();
-            this.emit(
-                'warn',
-                `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${result}`,
-            );
-        }
-        this.count(name, result);
-        return result;
-    }
+  getFeatureToggleDefinitions(): FeatureInterface[] {
+    return this.repository.getToggles();
+  }
 
-    getVariant(name: string, context: any, fallbackVariant?: Variant): Variant {
-        const enhancedContext = Object.assign({}, this.staticContext, context);
-        let result;
-        if (this.client !== undefined) {
-            result = this.client.getVariant(name, enhancedContext, fallbackVariant);
-        } else {
-            result = typeof fallbackVariant !== 'undefined' ? fallbackVariant : getDefaultVariant();
-            this.emit(
-                'warn',
-                `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${result}`,
-            );
-        }
-        if (result.name) {
-            this.countVariant(name, result.name);
-        } else {
-            this.count(name, result.enabled);
-        }
+  count(toggleName: string, enabled: boolean) {
+    this.metrics.count(toggleName, enabled);
+  }
 
-        return result;
-    }
-
-    getFeatureToggleDefinition(toggleName: string): FeatureInterface {
-        return this.repository.getToggle(toggleName);
-    }
-
-    getFeatureToggleDefinitions(): FeatureInterface[] {
-        return this.repository.getToggles();
-    }
-
-    count(toggleName: string, enabled: boolean) {
-        this.metrics.count(toggleName, enabled);
-    }
-
-    countVariant(toggleName: string, variantName: string) {
-        this.metrics.countVariant(toggleName, variantName);
-    }
+  countVariant(toggleName: string, variantName: string) {
+    this.metrics.countVariant(toggleName, variantName);
+  }
 }

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -1,92 +1,92 @@
 import { Context } from './context';
+// eslint-disable-next-line import/no-cycle
 import { FeatureInterface } from './feature';
-import { normalizedValue } from './strategy/util';
+import normalizedValue from './strategy/util';
 import { resolveContextValue } from './helpers';
 
 enum PayloadType {
-    STRING = 'string',
+  STRING = 'string',
 }
 
 interface Override {
-    contextName: string;
-    values: String[];
+  contextName: string;
+  values: String[];
 }
 
 export interface Payload {
-    type: PayloadType;
-    value: string;
+  type: PayloadType;
+  value: string;
 }
 
 export interface VariantDefinition {
-    name: string;
-    weight: number;
-    payload: Payload;
-    overrides: Override[];
+  name: string;
+  weight: number;
+  payload: Payload;
+  overrides: Override[];
 }
 
 export interface Variant {
-    name: string;
-    enabled: boolean;
-    payload?: Payload;
+  name: string;
+  enabled: boolean;
+  payload?: Payload;
 }
 
 export function getDefaultVariant(): Variant {
-    return {
-        name: 'disabled',
-        enabled: false,
-    };
+  return {
+    name: 'disabled',
+    enabled: false,
+  };
 }
 
 const stickynessSelectors = ['userId', 'sessionId', 'remoteAddress'];
 function getSeed(context: Context): string {
-    let result;
-    stickynessSelectors.some((key: string): boolean => {
-        const value = context[key];
-        if (typeof value === 'string' && value !== '') {
-            result = value;
-            return true;
-        }
-        return false;
-    });
-    return result || String(Math.round(Math.random() * 100000));
+  let result;
+  stickynessSelectors.some((key: string): boolean => {
+    const value = context[key];
+    if (typeof value === 'string' && value !== '') {
+      result = value;
+      return true;
+    }
+    return false;
+  });
+  return result || String(Math.round(Math.random() * 100000));
 }
 
 function overrideMatchesContext(context: Context): (o: Override) => boolean {
-    return (o: Override) =>
-        o.values.some(value => value === resolveContextValue(context, o.contextName));
+  return (o: Override) =>
+    o.values.some((value) => value === resolveContextValue(context, o.contextName));
 }
 
 function findOverride(feature: FeatureInterface, context: Context): VariantDefinition | undefined {
-    return feature.variants
-        .filter(variant => variant.overrides)
-        .find(variant => variant.overrides.some(overrideMatchesContext(context)));
+  return feature.variants
+    .filter((variant) => variant.overrides)
+    .find((variant) => variant.overrides.some(overrideMatchesContext(context)));
 }
 
 export function selectVariant(
-    feature: FeatureInterface,
-    context: Context,
+  feature: FeatureInterface,
+  context: Context,
 ): VariantDefinition | null {
-    const totalWeight = feature.variants.reduce((acc, v) => acc + v.weight, 0);
-    if (totalWeight <= 0) {
-        return null;
-    }
-    const variantOverride = findOverride(feature, context);
-    if (variantOverride) {
-        return variantOverride;
-    }
-    const target = normalizedValue(getSeed(context), feature.name, totalWeight);
+  const totalWeight = feature.variants.reduce((acc, v) => acc + v.weight, 0);
+  if (totalWeight <= 0) {
+    return null;
+  }
+  const variantOverride = findOverride(feature, context);
+  if (variantOverride) {
+    return variantOverride;
+  }
+  const target = normalizedValue(getSeed(context), feature.name, totalWeight);
 
-    let counter = 0;
-    const variant = feature.variants.find((v: VariantDefinition): any => {
-        if (v.weight === 0) {
-            return;
-        }
-        counter += v.weight;
-        if (counter < target) {
-            return;
-        } else {
-            return v;
-        }
-    });
-    return variant || null;
+  let counter = 0;
+  const variant = feature.variants.find((v: VariantDefinition): VariantDefinition | undefined => {
+    if (v.weight === 0) {
+      return undefined;
+    }
+    counter += v.weight;
+    if (counter < target) {
+      return undefined;
+    }
+    return v;
+  });
+  return variant || null;
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2,278 +2,261 @@ import test from 'ava';
 import Client from '../lib/client';
 import { Strategy } from '../lib/strategy';
 
+import CustomStrategy from './true_custom_strategy';
+import CustomFalseStrategy from './false_custom_strategy';
+
 function buildToggle(name, active, strategies, variants = []) {
-    return {
-        name,
-        enabled: active,
-        strategies: strategies || [{ name: 'default' }],
-        variants,
-    };
+  return {
+    name,
+    enabled: active,
+    strategies: strategies || [{ name: 'default' }],
+    variants,
+  };
 }
 
-class CustomStrategy extends Strategy {
-    constructor() {
-        super('custom');
-    }
-
-    isEnabled() {
-        return true;
-    }
-}
-
-class CustomFalseStrategy extends Strategy {
-    constructor() {
-        super('custom-false');
-    }
-
-    isEnabled() {
-        return false;
-    }
-}
-
-const log = err => {
-    console.error(err);
+const log = (err) => {
+  console.error(err);
 };
 
-test('invalid strategy should throw', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', true);
-        },
-    };
+test('invalid strategy should throw', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', true);
+    },
+  };
 
-    t.throws(() => new Client(repo, [true, null]));
-    t.throws(() => new Client(repo, [{}]));
-    t.throws(() => new Client(repo, [{ name: 'invalid' }]));
-    t.throws(() => new Client(repo, [{ isEnabled: 'invalid' }]));
-    t.throws(() => new Client(repo, [{ name: 'valid', isEnabled: () => {} }, null]));
+  t.throws(() => new Client(repo, [true, null]));
+  t.throws(() => new Client(repo, [{}]));
+  t.throws(() => new Client(repo, [{ name: 'invalid' }]));
+  t.throws(() => new Client(repo, [{ isEnabled: 'invalid' }]));
+  t.throws(() => new Client(repo, [{ name: 'valid', isEnabled: () => {} }, null]));
 });
 
-test('should use provided repository', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', true);
-        },
-    };
-    const client = new Client(repo, [new Strategy('default', true)]);
-    client.on('error', log).on('warn', log);
-    const result = client.isEnabled('feature');
+test('should use provided repository', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', true);
+    },
+  };
+  const client = new Client(repo, [new Strategy('default', true)]);
+  client.on('error', log).on('warn', log);
+  const result = client.isEnabled('feature');
 
-    t.true(result);
+  t.true(result);
 });
 
-test('should fallback when missing feature', t => {
-    const repo = {
-        getToggle() {
-            return null;
-        },
-    };
-    const client = new Client(repo, []);
-    client.on('error', log).on('warn', log);
+test('should fallback when missing feature', (t) => {
+  const repo = {
+    getToggle() {
+      return null;
+    },
+  };
+  const client = new Client(repo, []);
+  client.on('error', log).on('warn', log);
 
-    const result = client.isEnabled('feature-x', {}, () => false);
-    t.true(result === false);
+  const result = client.isEnabled('feature-x', {}, () => false);
+  t.true(result === false);
 
-    const result2 = client.isEnabled('feature-x', {}, () => true);
-    t.true(result2 === true);
+  const result2 = client.isEnabled('feature-x', {}, () => true);
+  t.true(result2 === true);
 });
 
-test('should consider toggle not active', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', false);
-        },
-    };
-    const client = new Client(repo, [new Strategy('default', true)]);
-    client.on('error', log).on('warn', log);
-    const result = client.isEnabled('feature');
+test('should consider toggle not active', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', false);
+    },
+  };
+  const client = new Client(repo, [new Strategy('default', true)]);
+  client.on('error', log).on('warn', log);
+  const result = client.isEnabled('feature');
 
-    t.true(!result);
+  t.true(!result);
 });
 
-test('should use custom strategy', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', true, [{ name: 'custom' }]);
-        },
-    };
-    const client = new Client(repo, [new Strategy('default', true), new CustomStrategy()]);
-    client.on('error', log).on('warn', log);
-    const result = client.isEnabled('feature');
+test('should use custom strategy', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', true, [{ name: 'custom' }]);
+    },
+  };
+  const client = new Client(repo, [new Strategy('default', true), new CustomStrategy()]);
+  client.on('error', log).on('warn', log);
+  const result = client.isEnabled('feature');
 
-    t.true(result);
+  t.true(result);
 });
 
-test('should use a set of custom strategies', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', true, [{ name: 'custom' }, { name: 'custom-false' }]);
-        },
-    };
+test('should use a set of custom strategies', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', true, [{ name: 'custom' }, { name: 'custom-false' }]);
+    },
+  };
 
-    const strategies = [new CustomFalseStrategy(), new CustomStrategy()];
-    const client = new Client(repo, strategies);
-    client.on('error', log).on('warn', log);
-    const result = client.isEnabled('feature');
+  const strategies = [new CustomFalseStrategy(), new CustomStrategy()];
+  const client = new Client(repo, strategies);
+  client.on('error', log).on('warn', log);
+  const result = client.isEnabled('feature');
 
-    t.true(result);
+  t.true(result);
 });
 
-test('should return false a set of custom-false strategies', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature', true, [
-                { name: 'custom-false' },
-                { name: 'custom-false' },
-            ]);
-        },
-    };
+test('should return false a set of custom-false strategies', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature', true, [
+        { name: 'custom-false' },
+        { name: 'custom-false' },
+      ]);
+    },
+  };
 
-    const strategies = [new CustomFalseStrategy(), new CustomStrategy()];
-    const client = new Client(repo, strategies);
-    client.on('error', log).on('warn', log);
-    const result = client.isEnabled('feature');
+  const strategies = [new CustomFalseStrategy(), new CustomStrategy()];
+  const client = new Client(repo, strategies);
+  client.on('error', log).on('warn', log);
+  const result = client.isEnabled('feature');
 
-    t.true(result === false);
+  t.true(result === false);
 });
 
-test('should emit error when invalid feature runtime', t => {
-    t.plan(3);
-    const repo = {
-        getToggle() {
-            return {
-                name: 'feature-malformed-strategies',
-                enabled: true,
-                strategies: true,
-            };
-        },
-    };
+test('should emit error when invalid feature runtime', (t) => {
+  t.plan(3);
+  const repo = {
+    getToggle() {
+      return {
+        name: 'feature-malformed-strategies',
+        enabled: true,
+        strategies: true,
+      };
+    },
+  };
 
-    const strategies = [];
-    const client = new Client(repo, strategies);
-    client.on('error', err => {
-        t.truthy(err);
-        t.true(err.message.startsWith('Malformed feature'));
-    });
-    client.on('warn', log);
+  const strategies = [];
+  const client = new Client(repo, strategies);
+  client.on('error', (err) => {
+    t.truthy(err);
+    t.true(err.message.startsWith('Malformed feature'));
+  });
+  client.on('warn', log);
 
-    t.true(client.isEnabled('feature-malformed-strategies') === false);
+  t.true(client.isEnabled('feature-malformed-strategies') === false);
 });
 
-test('should emit error when mising feature runtime', t => {
-    t.plan(3);
-    const repo = {
-        getToggle() {
-            return {
-                name: 'feature-wrong-strategy',
-                enabled: true,
-                strategies: [{ name: 'non-existent' }],
-            };
-        },
-    };
+test('should emit error when mising feature runtime', (t) => {
+  t.plan(3);
+  const repo = {
+    getToggle() {
+      return {
+        name: 'feature-wrong-strategy',
+        enabled: true,
+        strategies: [{ name: 'non-existent' }],
+      };
+    },
+  };
 
-    const strategies = [];
-    const client = new Client(repo, strategies);
-    client.on('error', log);
-    client.on('warn', msg => {
-        t.truthy(msg);
-        t.true(msg.startsWith('Missing strategy'));
-    });
+  const strategies = [];
+  const client = new Client(repo, strategies);
+  client.on('error', log);
+  client.on('warn', (msg) => {
+    t.truthy(msg);
+    t.true(msg.startsWith('Missing strategy'));
+  });
 
-    t.true(client.isEnabled('feature-wrong-strategy') === false);
+  t.true(client.isEnabled('feature-wrong-strategy') === false);
 });
 
 [
-    [
-        ['y', 1],
-        ['0', 1],
-        ['1', 1],
-    ],
-    [
-        ['3', 33],
-        ['2', 33],
-        ['0', 33],
-    ],
-    [
-        ['aaa', 100],
-        ['3', 100],
-        ['1', 100],
-    ],
+  [
+    ['y', 1],
+    ['0', 1],
+    ['1', 1],
+  ],
+  [
+    ['3', 33],
+    ['2', 33],
+    ['0', 33],
+  ],
+  [
+    ['aaa', 100],
+    ['3', 100],
+    ['1', 100],
+  ],
 ].forEach(([[id1, weight1], [id2, weight2], [id3, weight3]]) => {
-    test(`should return variant when equal weight on ${weight1},${weight2},${weight3}`, t => {
-        const repo = {
-            getToggle() {
-                return buildToggle('feature', true, null, [
-                    {
-                        name: 'variant1',
-                        weight: weight1,
-                        payload: {
-                            type: 'string',
-                            value: 'val1',
-                        },
-                    },
-                    {
-                        name: 'variant2',
-                        weight: weight2,
-                        payload: {
-                            type: 'string',
-                            value: 'val2',
-                        },
-                    },
-                    {
-                        name: 'variant3',
-                        weight: weight3,
-                        payload: {
-                            type: 'string',
-                            value: 'val3',
-                        },
-                    },
-                ]);
+  test(`should return variant when equal weight on ${weight1},${weight2},${weight3}`, (t) => {
+    const repo = {
+      getToggle() {
+        return buildToggle('feature', true, null, [
+          {
+            name: 'variant1',
+            weight: weight1,
+            payload: {
+              type: 'string',
+              value: 'val1',
             },
-        };
+          },
+          {
+            name: 'variant2',
+            weight: weight2,
+            payload: {
+              type: 'string',
+              value: 'val2',
+            },
+          },
+          {
+            name: 'variant3',
+            weight: weight3,
+            payload: {
+              type: 'string',
+              value: 'val3',
+            },
+          },
+        ]);
+      },
+    };
 
-        const strategies = [new Strategy('default', true)];
-        const client = new Client(repo, strategies);
-        client.on('error', log).on('warn', log);
-        const result = client.isEnabled('feature');
+    const strategies = [new Strategy('default', true)];
+    const client = new Client(repo, strategies);
+    client.on('error', log).on('warn', log);
+    const result = client.isEnabled('feature');
 
-        t.true(result === true);
+    t.true(result === true);
 
-        [id1, id2, id3].forEach(id => {
-            t.snapshot(client.getVariant('feature', { userId: id }));
-        });
+    [id1, id2, id3].forEach((id) => {
+      t.snapshot(client.getVariant('feature', { userId: id }));
     });
+  });
 });
 
-test('should always return defaultVariant if missing variant', t => {
-    const repo = {
-        getToggle() {
-            return buildToggle('feature-but-no-variant', true, []);
-        },
-    };
+test('should always return defaultVariant if missing variant', (t) => {
+  const repo = {
+    getToggle() {
+      return buildToggle('feature-but-no-variant', true, []);
+    },
+  };
 
-    const client = new Client(repo);
+  const client = new Client(repo);
 
-    client.on('error', log).on('warn', log);
-    const result = client.getVariant('feature-but-no-variant', {});
-    const defaultVariant = {
-        enabled: false,
-        name: 'disabled',
-    };
-    t.deepEqual(result, defaultVariant);
+  client.on('error', log).on('warn', log);
+  const result = client.getVariant('feature-but-no-variant', {});
+  const defaultVariant = {
+    enabled: false,
+    name: 'disabled',
+  };
+  t.deepEqual(result, defaultVariant);
 
-    const fallback = {
-        enabled: false,
-        name: 'customDisabled',
-        payload: {
-            type: 'string',
-            value: '',
-        },
-    };
-    const result2 = client.getVariant('feature-but-no-variant', {}, fallback);
+  const fallback = {
+    enabled: false,
+    name: 'customDisabled',
+    payload: {
+      type: 'string',
+      value: '',
+    },
+  };
+  const result2 = client.getVariant('feature-but-no-variant', {}, fallback);
 
-    t.deepEqual(result2, fallback);
+  t.deepEqual(result2, fallback);
 
-    const result3 = client.getVariant('missing-feature-x', {});
-    t.deepEqual(result3, defaultVariant);
+  const result3 = client.getVariant('missing-feature-x', {});
+  t.deepEqual(result3, defaultVariant);
 });

--- a/test/fake_repo.js
+++ b/test/fake_repo.js
@@ -1,0 +1,20 @@
+import { EventEmitter } from 'events';
+
+export default class FakeRepo extends EventEmitter {
+  constructor() {
+    super();
+    this.data = {
+      name: 'fake-feature',
+      enabled: false,
+      strategies: [],
+    };
+  }
+
+  stop() {
+
+  }
+
+  getToggle() {
+    return this.data;
+  }
+}

--- a/test/false_custom_strategy.js
+++ b/test/false_custom_strategy.js
@@ -1,0 +1,11 @@
+import { Strategy } from '../lib';
+
+export default class CustomFalseStrategy extends Strategy {
+  constructor() {
+    super('custom-false');
+  }
+
+  isEnabled() {
+    return false;
+  }
+}

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -7,58 +7,59 @@ import mkdirp from 'mkdirp';
 import { initialize, isEnabled, destroy } from '../lib/index';
 
 function getRandomBackupPath() {
-    const path = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
-    mkdirp.sync(path);
-    return path;
+  const path = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
+  mkdirp.sync(path);
+  return path;
 }
 
 const defaultToggles = [
-    {
-        name: 'feature',
-        enabled: true,
-        strategies: [],
-    },
+  {
+    name: 'feature',
+    enabled: true,
+    strategies: [],
+  },
 ];
 
 let counter = 0;
 function mockNetwork(toggles = defaultToggles) {
-    const url = `http://unleash-${counter++}.app`;
-    nock(url)
-        .get('/client/features')
-        .reply(200, { features: toggles });
-    return url;
+  counter += 1;
+  const url = `http://unleash-${counter}.app`;
+  nock(url)
+    .get('/client/features')
+    .reply(200, { features: toggles });
+  return url;
 }
 
-test('should be able to call api', t => {
-    const url = mockNetwork();
-    initialize({
-        appName: 'foo',
-        metricsInterval: 0,
-        url,
-        backupPath: getRandomBackupPath(),
-    }).on('error', err => {
-        throw err;
-    });
-    t.true(isEnabled('unknown') === false);
-    destroy();
+test('should be able to call api', (t) => {
+  const url = mockNetwork();
+  initialize({
+    appName: 'foo',
+    metricsInterval: 0,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', (err) => {
+    throw err;
+  });
+  t.true(isEnabled('unknown') === false);
+  destroy();
 });
 
-test.cb('should be able to call isEnabled eventually', t => {
-    const url = mockNetwork();
-    const instance = initialize({
-        appName: 'foo',
-        metricsInterval: 0,
-        url,
-        backupPath: getRandomBackupPath(),
-    }).on('error', err => {
-        throw err;
-    });
+test.cb('should be able to call isEnabled eventually', (t) => {
+  const url = mockNetwork();
+  const instance = initialize({
+    appName: 'foo',
+    metricsInterval: 0,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', (err) => {
+    throw err;
+  });
 
-    instance.on('ready', () => {
-        t.true(isEnabled('feature') === true);
-        t.end();
-        destroy();
-    });
+  instance.on('ready', () => {
+    t.true(isEnabled('feature') === true);
+    t.end();
+    destroy();
+  });
 
-    t.true(isEnabled('feature') === false);
+  t.true(isEnabled('feature') === false);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,57 +1,55 @@
 import test from 'ava';
-import {
-    initialize,
-    isEnabled,
-    Strategy,
-    destroy,
-    getFeatureToggleDefinition,
-    getFeatureToggleDefinitions,
-    count,
-    countVariant,
-    getVariant,
-} from '../lib/index';
 import nock from 'nock';
+import {
+  initialize,
+  isEnabled,
+  Strategy,
+  destroy,
+  getFeatureToggleDefinition,
+  getFeatureToggleDefinitions,
+  count,
+  countVariant,
+  getVariant,
+} from '../lib/index';
 
 let counter = 1;
-const getUrl = () => `http://test${counter++}.app/`;
+const getUrl = () => { const url = `http://test${counter}.app/`; counter += 1; return url; };
 const metricsUrl = '/client/metrics';
-const nockMetrics = (url, code = 200) =>
-    nock(url)
-        .post(metricsUrl)
-        .reply(code, '');
+const nockMetrics = (url, code = 200) => nock(url)
+  .post(metricsUrl)
+  .reply(code, '');
 const registerUrl = '/client/register';
-const nockRegister = (url, code = 200) =>
-    nock(url)
-        .post(registerUrl)
-        .reply(code, '');
+const nockRegister = (url, code = 200) => nock(url)
+  .post(registerUrl)
+  .reply(code, '');
 
-test('should load main module', t => {
-    t.truthy(initialize);
-    t.truthy(isEnabled);
-    t.truthy(Strategy);
-    t.truthy(destroy);
-    t.truthy(countVariant);
-    t.truthy(getVariant);
-    t.truthy(getFeatureToggleDefinition);
-    t.truthy(getFeatureToggleDefinitions);
-    t.truthy(count);
+test('should load main module', (t) => {
+  t.truthy(initialize);
+  t.truthy(isEnabled);
+  t.truthy(Strategy);
+  t.truthy(destroy);
+  t.truthy(countVariant);
+  t.truthy(getVariant);
+  t.truthy(getFeatureToggleDefinition);
+  t.truthy(getFeatureToggleDefinitions);
+  t.truthy(count);
 });
 
-test('initialize should init with valid options', t => {
-    const url = getUrl();
-    nockMetrics(url);
-    nockRegister(url);
-    t.notThrows(() => initialize({ appName: 'my-app-name', url }));
+test('initialize should init with valid options', (t) => {
+  const url = getUrl();
+  nockMetrics(url);
+  nockRegister(url);
+  t.notThrows(() => initialize({ appName: 'my-app-name', url }));
 });
 
-test('should call methods', t => {
-    const url = getUrl();
-    nockMetrics(url);
-    nockRegister(url);
-    t.notThrows(() => initialize({ appName: 'my-app-name', url }));
-    t.snapshot(isEnabled('some-feature'));
-    t.snapshot(getFeatureToggleDefinition('some-feature'));
-    t.snapshot(getVariant('some-feature'));
-    t.snapshot(count('some-feature', true));
-    t.snapshot(countVariant('some-feature', 'variant1'));
+test('should call methods', (t) => {
+  const url = getUrl();
+  nockMetrics(url);
+  nockRegister(url);
+  t.notThrows(() => initialize({ appName: 'my-app-name', url }));
+  t.snapshot(isEnabled('some-feature'));
+  t.snapshot(getFeatureToggleDefinition('some-feature'));
+  t.snapshot(getVariant('some-feature'));
+  t.snapshot(count('some-feature', true));
+  t.snapshot(countVariant('some-feature', 'variant1'));
 });

--- a/test/integration/client-specification.test.js
+++ b/test/integration/client-specification.test.js
@@ -11,71 +11,70 @@ let counter = 1;
 const getUrl = () => `http://client-spec-${counter++}.app/`;
 
 function getRandomBackupPath(testName) {
-    const path = join(tmpdir(), `test-${testName}-${Math.round(Math.random() * 100000)}`);
-    mkdirp.sync(path);
-    return path;
+  const path = join(tmpdir(), `test-${testName}-${Math.round(Math.random() * 100000)}`);
+  mkdirp.sync(path);
+  return path;
 }
 
 function mockNetwork(toggles, url = getUrl()) {
-    nock(url)
-        .get('/client/features')
-        .reply(200, toggles);
-    return url;
+  nock(url)
+    .get('/client/features')
+    .reply(200, toggles);
+  return url;
 }
 
-specs.forEach(testName => {
-    const definition = require(`@unleash/client-specification/specifications/${testName}`);
+specs.forEach((testName) => {
+  // eslint-disable-next-line
+  const definition = require(`@unleash/client-specification/specifications/${testName}`);
 
-    if (definition.tests) {
-        definition.tests.forEach(testCase => {
-            test(`${testName}:${testCase.description}`, t =>
-                new Promise((resolve, reject) => {
-                    // Mock unleash-api
-                    const url = mockNetwork(definition.state);
+  if (definition.tests) {
+    definition.tests.forEach((testCase) => {
+      test(`${testName}:${testCase.description}`, (t) => new Promise((resolve, reject) => {
+        // Mock unleash-api
+        const url = mockNetwork(definition.state);
 
-                    // New unleash instance
-                    const instance = new Unleash({
-                        appName: testName,
-                        disableMetrics: true,
-                        url,
-                        backupPath: getRandomBackupPath(definition.name),
-                    });
-
-                    instance.on('error', reject);
-                    instance.on('ready', () => {
-                        const result = instance.isEnabled(testCase.toggleName, testCase.context);
-                        t.is(result, testCase.expectedResult);
-                        instance.destroy();
-                        resolve();
-                    });
-                }));
+        // New unleash instance
+        const instance = new Unleash({
+          appName: testName,
+          disableMetrics: true,
+          url,
+          backupPath: getRandomBackupPath(definition.name),
         });
-    }
 
-    if (definition.variantTests) {
-        definition.variantTests.forEach(testCase => {
-            test(`${testName}:${testCase.description}`, t =>
-                new Promise((resolve, reject) => {
-                    // Mock unleash-api
-                    const url = mockNetwork(definition.state);
-
-                    // New unleash instance
-                    const instance = new Unleash({
-                        appName: testName,
-                        disableMetrics: true,
-                        url,
-                        backupPath: getRandomBackupPath(definition.name),
-                    });
-
-                    instance.on('error', reject);
-                    instance.on('ready', () => {
-                        const result = instance.getVariant(testCase.toggleName, testCase.context);
-                        t.deepEqual(result, testCase.expectedResult);
-
-                        instance.destroy();
-                        resolve();
-                    });
-                }));
+        instance.on('error', reject);
+        instance.on('ready', () => {
+          const result = instance.isEnabled(testCase.toggleName, testCase.context);
+          t.is(result, testCase.expectedResult);
+          instance.destroy();
+          resolve();
         });
-    }
+      }));
+    });
+  }
+
+  if (definition.variantTests) {
+    definition.variantTests.forEach((testCase) => {
+      test(`${testName}:${testCase.description}`, (t) => new Promise((resolve, reject) => {
+        // Mock unleash-api
+        const url = mockNetwork(definition.state);
+
+        // New unleash instance
+        const instance = new Unleash({
+          appName: testName,
+          disableMetrics: true,
+          url,
+          backupPath: getRandomBackupPath(definition.name),
+        });
+
+        instance.on('error', reject);
+        instance.on('ready', () => {
+          const result = instance.getVariant(testCase.toggleName, testCase.context);
+          t.deepEqual(result, testCase.expectedResult);
+
+          instance.destroy();
+          resolve();
+        });
+      }));
+    });
+  }
 });

--- a/test/integration/constraint.test.js
+++ b/test/integration/constraint.test.js
@@ -10,107 +10,105 @@ let counter = 1;
 const getUrl = () => `http://client-spec-${counter++}.app/`;
 
 function getRandomBackupPath(testName) {
-    const path = join(tmpdir(), `test-${testName}-${Math.round(Math.random() * 100000)}`);
-    mkdirp.sync(path);
-    return path;
+  const path = join(tmpdir(), `test-${testName}-${Math.round(Math.random() * 100000)}`);
+  mkdirp.sync(path);
+  return path;
 }
 
 function mockNetwork(toggles, url = getUrl()) {
-    nock(url)
-        .get('/client/features')
-        .reply(200, toggles);
-    return url;
+  nock(url)
+    .get('/client/features')
+    .reply(200, toggles);
+  return url;
 }
 
 const toggles = {
-    version: 1,
-    features: [
+  version: 1,
+  features: [
+    {
+      name: 'toggle.with.constraint.enabled',
+      description: 'readme',
+      enabled: true,
+      strategies: [
         {
-            name: 'toggle.with.constraint.enabled',
-            description: 'readme',
-            enabled: true,
-            strategies: [
-                {
-                    name: 'default',
-                    constraints: [
-                        { contextName: 'environment', operator: 'IN', values: ['test', 'dev'] },
-                    ],
-                },
-            ],
+          name: 'default',
+          constraints: [
+            { contextName: 'environment', operator: 'IN', values: ['test', 'dev'] },
+          ],
         },
+      ],
+    },
+    {
+      name: 'toggle.with.constraint.enabled',
+      description: 'readme',
+      enabled: true,
+      strategies: [
         {
-            name: 'toggle.with.constraint.enabled',
-            description: 'readme',
-            enabled: true,
-            strategies: [
-                {
-                    name: 'default',
-                    constraints: [
-                        { contextName: 'environment', operator: 'IN', values: ['test', 'dev'] },
-                    ],
-                },
-            ],
+          name: 'default',
+          constraints: [
+            { contextName: 'environment', operator: 'IN', values: ['test', 'dev'] },
+          ],
         },
+      ],
+    },
+    {
+      name: 'toggle.with.constraint.not_in.enabled',
+      description: 'readme',
+      enabled: true,
+      strategies: [
         {
-            name: 'toggle.with.constraint.not_in.enabled',
-            description: 'readme',
-            enabled: true,
-            strategies: [
-                {
-                    name: 'default',
-                    constraints: [
-                        { contextName: 'environment', operator: 'NOT_IN', values: ['prod', 'dev'] },
-                    ],
-                },
-            ],
+          name: 'default',
+          constraints: [
+            { contextName: 'environment', operator: 'NOT_IN', values: ['prod', 'dev'] },
+          ],
         },
-    ],
+      ],
+    },
+  ],
 };
 
-test('should be enabled for satisfied constraint', t =>
-    new Promise((resolve, reject) => {
-        // Mock unleash-api
-        const url = mockNetwork(toggles);
+test('should be enabled for satisfied constraint', (t) => new Promise((resolve, reject) => {
+  // Mock unleash-api
+  const url = mockNetwork(toggles);
 
-        // New unleash instance
-        const instance = new Unleash({
-            appName: 'Test',
-            disableMetrics: true,
-            environment: 'test',
-            url,
-            backupPath: getRandomBackupPath('with-constraint'),
-        });
+  // New unleash instance
+  const instance = new Unleash({
+    appName: 'Test',
+    disableMetrics: true,
+    environment: 'test',
+    url,
+    backupPath: getRandomBackupPath('with-constraint'),
+  });
 
-        instance.on('error', reject);
-        instance.on('ready', () => {
-            const result = instance.isEnabled('toggle.with.constraint.enabled');
-            t.is(result, true);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('error', reject);
+  instance.on('ready', () => {
+    const result = instance.isEnabled('toggle.with.constraint.enabled');
+    t.is(result, true);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('should be enabled for satisfied NOT_IN constraint', t =>
-    new Promise((resolve, reject) => {
-        // Mock unleash-api
-        const url = mockNetwork(toggles);
+test('should be enabled for satisfied NOT_IN constraint', (t) => new Promise((resolve, reject) => {
+  // Mock unleash-api
+  const url = mockNetwork(toggles);
 
-        // New unleash instance
-        const instance = new Unleash({
-            appName: 'Test',
-            disableMetrics: true,
-            environment: 'test',
-            url,
-            backupPath: getRandomBackupPath('with-constraint'),
-        });
+  // New unleash instance
+  const instance = new Unleash({
+    appName: 'Test',
+    disableMetrics: true,
+    environment: 'test',
+    url,
+    backupPath: getRandomBackupPath('with-constraint'),
+  });
 
-        instance.on('error', reject);
-        instance.on('ready', () => {
-            const result = instance.isEnabled('toggle.with.constraint.not_in.enabled', {
-                userId: '123',
-            });
-            t.is(result, true);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('error', reject);
+  instance.on('ready', () => {
+    const result = instance.isEnabled('toggle.with.constraint.not_in.enabled', {
+      userId: '123',
+    });
+    t.is(result, true);
+    instance.destroy();
+    resolve();
+  });
+}));

--- a/test/metrics.network.test.js
+++ b/test/metrics.network.test.js
@@ -6,6 +6,7 @@ test.before(() => nock.disableNetConnect());
 test.after(() => nock.enableNetConnect());
 
 test.cb('registerInstance should emit error when request error', (t) => {
+  t.plan(2);
   const url = 'http://metrics1.app/';
 
   const metrics = new Metrics({
@@ -13,7 +14,6 @@ test.cb('registerInstance should emit error when request error', (t) => {
   });
   metrics.on('error', (e) => {
     t.truthy(e);
-    t.end();
   });
 
   metrics.registerInstance().then((result) => {
@@ -23,6 +23,7 @@ test.cb('registerInstance should emit error when request error', (t) => {
 });
 
 test.cb('sendMetrics should emit error when request error', (t) => {
+  t.plan(2);
   const url = 'http://metrics2.app/';
 
   const metrics = new Metrics({
@@ -30,7 +31,6 @@ test.cb('sendMetrics should emit error when request error', (t) => {
   });
   metrics.on('error', (e) => {
     t.truthy(e);
-    t.end();
   });
 
   metrics.count('x', true);

--- a/test/metrics.network.test.js
+++ b/test/metrics.network.test.js
@@ -1,42 +1,42 @@
 import test from 'ava';
-import Metrics from '../lib/metrics';
 import nock from 'nock';
+import Metrics from '../lib/metrics';
 
 test.before(() => nock.disableNetConnect());
 test.after(() => nock.enableNetConnect());
 
-test.cb('registerInstance should emit error when request error', t => {
-    t.plan(2);
-    const url = 'http://metrics1.app/';
+test.cb('registerInstance should emit error when request error', (t) => {
+  const url = 'http://metrics1.app/';
 
-    const metrics = new Metrics({
-        url,
-    });
-    metrics.on('error', e => {
-        t.truthy(e);
-    });
+  const metrics = new Metrics({
+    url,
+  });
+  metrics.on('error', (e) => {
+    t.truthy(e);
+    t.end();
+  });
 
-    metrics.registerInstance().then(result => {
-        t.true(result);
-        t.end();
-    });
+  metrics.registerInstance().then((result) => {
+    t.true(result);
+    t.end();
+  });
 });
 
-test.cb('sendMetrics should emit error when request error', t => {
-    t.plan(2);
-    const url = 'http://metrics2.app/';
+test.cb('sendMetrics should emit error when request error', (t) => {
+  const url = 'http://metrics2.app/';
 
-    const metrics = new Metrics({
-        url,
-    });
-    metrics.on('error', e => {
-        t.truthy(e);
-    });
+  const metrics = new Metrics({
+    url,
+  });
+  metrics.on('error', (e) => {
+    t.truthy(e);
+    t.end();
+  });
 
-    metrics.count('x', true);
+  metrics.count('x', true);
 
-    metrics.sendMetrics().then(result => {
-        t.true(result);
-        t.end();
-    });
+  metrics.sendMetrics().then((result) => {
+    t.true(result);
+    t.end();
+  });
 });

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -221,7 +221,7 @@ test.only('should respect timeout', t =>
     }));
 */
 
-test.cb('registerInstance should warn when non 200 statusCode', (t) => {
+test('registerInstance should warn when non 200 statusCode', async (t) => {
   t.plan(2);
   const url = getUrl();
   const regEP = nockRegister(url, 500);
@@ -236,10 +236,9 @@ test.cb('registerInstance should warn when non 200 statusCode', (t) => {
   metrics.on('warn', (e) => {
     t.true(regEP.isDone());
     t.truthy(e);
-    t.end();
   });
 
-  metrics.registerInstance().then(t.true);
+  await metrics.registerInstance();
 });
 
 test.cb('sendMetrics should stop/disable metrics if endpoint returns 404', (t) => {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -222,6 +222,7 @@ test.only('should respect timeout', t =>
 */
 
 test.cb('registerInstance should warn when non 200 statusCode', (t) => {
+  t.plan(2);
   const url = getUrl();
   const regEP = nockRegister(url, 500);
 

--- a/test/repository.test.js
+++ b/test/repository.test.js
@@ -8,312 +8,312 @@ const appName = 'foo';
 const instanceId = 'bar';
 
 class MockStorage extends EventEmitter {
-    constructor() {
-        super();
-        this.data = {};
-        process.nextTick(() => this.emit('ready'));
-    }
+  constructor() {
+    super();
+    this.data = {};
+    process.nextTick(() => this.emit('ready'));
+  }
 
-    reset(data) {
-        this.data = data;
-    }
+  reset(data) {
+    this.data = data;
+  }
 
-    get(name) {
-        return this.data[name];
-    }
+  get(name) {
+    return this.data[name];
+  }
 
-    getAll() {
-        return this.data;
-    }
+  getAll() {
+    return this.data;
+  }
 }
 
 function setup(url, toggles, headers = {}) {
-    return nock(url)
-        .persist()
-        .get('/client/features')
-        .reply(200, { features: toggles }, headers);
+  return nock(url)
+    .persist()
+    .get('/client/features')
+    .reply(200, { features: toggles }, headers);
 }
 
 test.cb('should fetch from endpoint', t => {
-    const url = 'http://unleash-test-0.app';
-    const feature = {
-        name: 'feature',
-        enabled: true,
-        strategies: [
-            {
-                name: 'default',
-            },
-        ],
-    };
+  const url = 'http://unleash-test-0.app';
+  const feature = {
+    name: 'feature',
+    enabled: true,
+    strategies: [
+      {
+        name: 'default',
+      },
+    ],
+  };
 
-    setup(url, [feature]);
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-    });
+  setup(url, [feature]);
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+  });
 
-    repo.once('changed', () => {
-        const savedFeature = repo.storage.data[feature.name];
-        t.true(savedFeature.enabled === feature.enabled);
-        t.true(savedFeature.strategies[0].name === feature.strategies[0].name);
+  repo.once('changed', () => {
+    const savedFeature = repo.storage.data[feature.name];
+    t.true(savedFeature.enabled === feature.enabled);
+    t.true(savedFeature.strategies[0].name === feature.strategies[0].name);
 
-        const featureToggles = repo.getToggles();
-        t.true(featureToggles[0].name === 'feature');
+    const featureToggles = repo.getToggles();
+    t.true(featureToggles[0].name === 'feature');
 
-        const featureToggle = repo.getToggle('feature');
-        t.truthy(featureToggle);
-        t.end();
-    });
+    const featureToggle = repo.getToggle('feature');
+    t.truthy(featureToggle);
+    t.end();
+  });
 });
 
 test('should poll for changes', t =>
-    new Promise((resolve, reject) => {
-        const url = 'http://unleash-test-2.app';
-        setup(url, []);
-        const repo = new Repository({
-            backupPath: 'foo-bar',
-            url,
-            appName,
-            instanceId,
-            refreshInterval: 10,
-            StorageImpl: MockStorage,
-        });
+  new Promise((resolve, reject) => {
+    const url = 'http://unleash-test-2.app';
+    setup(url, []);
+    const repo = new Repository({
+      backupPath: 'foo-bar',
+      url,
+      appName,
+      instanceId,
+      refreshInterval: 10,
+      StorageImpl: MockStorage,
+    });
 
-        let assertCount = 5;
-        repo.on('unchanged', resolve);
-        repo.on('changed', () => {
-            assertCount--;
+    let assertCount = 5;
+    repo.on('unchanged', resolve);
+    repo.on('changed', () => {
+      assertCount--;
 
-            if (assertCount === 0) {
-                repo.stop();
-                t.true(assertCount === 0);
-                resolve();
-            }
-        });
+      if (assertCount === 0) {
+        repo.stop();
+        t.true(assertCount === 0);
+        resolve();
+      }
+    });
 
-        repo.on('error', reject);
-    }));
+    repo.on('error', reject);
+  }));
 
 test('should retry even if custom header function fails', t =>
-    new Promise(resolve => {
-        const url = 'http://unleash-test-2-custom-headers.app';
-        setup(url, []);
-        const repo = new Repository({
-            backupPath: 'foo-bar',
-            url,
-            appName,
-            instanceId,
-            refreshInterval: 10,
-            customHeadersFunction: () => {
-                throw new Error('custom function fails');
-            },
-            StorageImpl: MockStorage,
-        });
+  new Promise(resolve => {
+    const url = 'http://unleash-test-2-custom-headers.app';
+    setup(url, []);
+    const repo = new Repository({
+      backupPath: 'foo-bar',
+      url,
+      appName,
+      instanceId,
+      refreshInterval: 10,
+      customHeadersFunction: () => {
+        throw new Error('custom function fails');
+      },
+      StorageImpl: MockStorage,
+    });
 
-        let assertCount = 2;
-        repo.on('error', error => {
-            if (error.message === 'custom function fails') {
-                assertCount--;
-            }
-            if (assertCount === 0) {
-                repo.stop();
-                t.true(assertCount === 0);
-                resolve();
-            }
-        });
-    }));
+    let assertCount = 2;
+    repo.on('error', error => {
+      if (error.message === 'custom function fails') {
+        assertCount--;
+      }
+      if (assertCount === 0) {
+        repo.stop();
+        t.true(assertCount === 0);
+        resolve();
+      }
+    });
+  }));
 
 test('should store etag', t =>
-    new Promise(resolve => {
-        const url = 'http://unleash-test-3.app';
-        setup(url, [], { Etag: '12345' });
-        const repo = new Repository({
-            backupPath: 'foo',
-            url,
-            appName,
-            instanceId,
-            refreshInterval: 0,
-            StorageImpl: MockStorage,
-        });
+  new Promise(resolve => {
+    const url = 'http://unleash-test-3.app';
+    setup(url, [], { Etag: '12345' });
+    const repo = new Repository({
+      backupPath: 'foo',
+      url,
+      appName,
+      instanceId,
+      refreshInterval: 0,
+      StorageImpl: MockStorage,
+    });
 
-        repo.once('unchanged', resolve);
-        repo.once('changed', () => {
-            t.true(repo.etag === '12345');
+    repo.once('unchanged', resolve);
+    repo.once('changed', () => {
+      t.true(repo.etag === '12345');
 
-            resolve();
-        });
-    }));
+      resolve();
+    });
+  }));
 
 test.cb('should request with etag', t => {
-    const url = 'http://unleash-test-4.app';
-    nock(url)
-        .matchHeader('If-None-Match', '12345-1')
-        .persist()
-        .get('/client/features')
-        .reply(200, { features: [] }, { Etag: '12345-2' });
+  const url = 'http://unleash-test-4.app';
+  nock(url)
+    .matchHeader('If-None-Match', '12345-1')
+    .persist()
+    .get('/client/features')
+    .reply(200, { features: [] }, { Etag: '12345-2' });
 
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-    });
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+  });
 
-    repo.etag = '12345-1';
-    repo.once('unchanged', () => {
-        t.end();
-    });
-    repo.once('changed', () => {
-        t.true(repo.etag === '12345-2');
-        t.end();
-    });
+  repo.etag = '12345-1';
+  repo.once('unchanged', () => {
+    t.end();
+  });
+  repo.once('changed', () => {
+    t.true(repo.etag === '12345-2');
+    t.end();
+  });
 });
 
 test.cb('should request with custom headers', t => {
-    const url = 'http://unleash-test-4-x.app';
-    const randomKey = `random-${Math.random()}`;
-    nock(url)
-        .matchHeader('randomKey', randomKey)
-        .persist()
-        .get('/client/features')
-        .reply(200, { features: [] }, { Etag: '12345-3' });
+  const url = 'http://unleash-test-4-x.app';
+  const randomKey = `random-${Math.random()}`;
+  nock(url)
+    .matchHeader('randomKey', randomKey)
+    .persist()
+    .get('/client/features')
+    .reply(200, { features: [] }, { Etag: '12345-3' });
 
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-        headers: {
-            randomKey,
-        },
-    });
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+    headers: {
+      randomKey,
+    },
+  });
 
-    repo.etag = '12345-1';
-    repo.once('unchanged', () => {
-        t.end();
-    });
-    repo.once('changed', () => {
-        t.true(repo.etag === '12345-3');
-        t.end();
-    });
+  repo.etag = '12345-1';
+  repo.once('unchanged', () => {
+    t.end();
+  });
+  repo.once('changed', () => {
+    t.true(repo.etag === '12345-3');
+    t.end();
+  });
 });
 
 test.cb('request with customHeadersFunction should take precedence over customHeaders', t => {
-    const url = 'http://unleash-test-4-x.app';
-    const randomKey = `random-${Math.random()}`;
-    const customHeaderKey = `customer-${Math.random()}`;
-    nock(url)
-        .matchHeader('customHeaderKey', customHeaderKey)
-        .matchHeader('randomKey', value => value === undefined)
-        .persist()
-        .get('/client/features')
-        .reply(200, { features: [] }, { Etag: '12345-3' });
+  const url = 'http://unleash-test-4-x.app';
+  const randomKey = `random-${Math.random()}`;
+  const customHeaderKey = `customer-${Math.random()}`;
+  nock(url)
+    .matchHeader('customHeaderKey', customHeaderKey)
+    .matchHeader('randomKey', value => value === undefined)
+    .persist()
+    .get('/client/features')
+    .reply(200, { features: [] }, { Etag: '12345-3' });
 
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-        headers: {
-            randomKey,
-        },
-        customHeadersFunction: () => Promise.resolve({ customHeaderKey }),
-    });
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+    headers: {
+      randomKey,
+    },
+    customHeadersFunction: () => Promise.resolve({ customHeaderKey }),
+  });
 
-    repo.etag = '12345-1';
-    repo.once('unchanged', () => {
-        t.end();
-    });
-    repo.once('changed', () => {
-        t.true(repo.etag === '12345-3');
-        t.end();
-    });
+  repo.etag = '12345-1';
+  repo.once('unchanged', () => {
+    t.end();
+  });
+  repo.once('changed', () => {
+    t.true(repo.etag === '12345-3');
+    t.end();
+  });
 });
 
 test.cb('should handle 404 request error and emit error event', t => {
-    const url = 'http://unleash-test-5.app';
-    nock(url)
-        .persist()
-        .get('/client/features')
-        .reply(404, 'asd');
+  const url = 'http://unleash-test-5.app';
+  nock(url)
+    .persist()
+    .get('/client/features')
+    .reply(404, 'asd');
 
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-    });
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+  });
 
-    repo.on('error', err => {
-        t.truthy(err);
-        t.true(err.message.startsWith('Response was not statusCode 2'));
-        t.end();
-    });
+  repo.on('error', err => {
+    t.truthy(err);
+    t.true(err.message.startsWith('Response was not statusCode 2'));
+    t.end();
+  });
 });
 
 test('should handle 304 as silent ok', t => {
-    t.plan(0);
+  t.plan(0);
 
-    return new Promise((resolve, reject) => {
-        const url = 'http://unleash-test-6.app';
-        nock(url)
-            .persist()
-            .get('/client/features')
-            .reply(304, '');
+  return new Promise((resolve, reject) => {
+    const url = 'http://unleash-test-6.app';
+    nock(url)
+      .persist()
+      .get('/client/features')
+      .reply(304, '');
 
-        const repo = new Repository({
-            backupPath: 'foo',
-            url,
-            appName,
-            instanceId,
-            refreshInterval: 0,
-            StorageImpl: MockStorage,
-        });
-        repo.on('error', reject);
-        repo.on('unchanged', resolve);
-        process.nextTick(resolve);
+    const repo = new Repository({
+      backupPath: 'foo',
+      url,
+      appName,
+      instanceId,
+      refreshInterval: 0,
+      StorageImpl: MockStorage,
     });
+    repo.on('error', reject);
+    repo.on('unchanged', resolve);
+    process.nextTick(resolve);
+  });
 });
 
 test('should handle invalid JSON response', t =>
-    new Promise((resolve, reject) => {
-        const url = 'http://unleash-test-7.app';
-        nock(url)
-            .persist()
-            .get('/client/features')
-            .reply(200, '{"Invalid payload');
+  new Promise((resolve, reject) => {
+    const url = 'http://unleash-test-7.app';
+    nock(url)
+      .persist()
+      .get('/client/features')
+      .reply(200, '{"Invalid payload');
 
-        const repo = new Repository({
-            backupPath: 'foo',
-            url,
-            appName,
-            instanceId,
-            refreshInterval: 0,
-            StorageImpl: MockStorage,
-        });
-        repo.on('error', err => {
-            t.truthy(err);
-            t.true(
-                err.message.indexOf('Unexpected token') > -1 ||
-                    err.message.indexOf('Unexpected end of JSON input') > -1
-            );
-            resolve();
-        });
-        repo.on('unchanged', resolve);
-        repo.on('changed', reject);
-    }));
+    const repo = new Repository({
+      backupPath: 'foo',
+      url,
+      appName,
+      instanceId,
+      refreshInterval: 0,
+      StorageImpl: MockStorage,
+    });
+    repo.on('error', err => {
+      t.truthy(err);
+      t.true(
+        err.message.indexOf('Unexpected token') > -1 ||
+                    err.message.indexOf('Unexpected end of JSON input') > -1,
+      );
+      resolve();
+    });
+    repo.on('unchanged', resolve);
+    repo.on('changed', reject);
+  }));
 /*
 test('should respect timeout', t =>
     new Promise((resolve, reject) => {
@@ -343,55 +343,55 @@ test('should respect timeout', t =>
 */
 
 test.cb('should emit errors on invalid features', t => {
-    const url = 'http://unleash-test-1.app';
-    setup(url, [
-        {
-            name: 'feature',
-            enabled: null,
-            strategies: false,
-        },
-    ]);
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-    });
+  const url = 'http://unleash-test-1.app';
+  setup(url, [
+    {
+      name: 'feature',
+      enabled: null,
+      strategies: false,
+    },
+  ]);
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+  });
 
-    repo.once('error', err => {
-        t.truthy(err);
-        t.end();
-    });
+  repo.once('error', err => {
+    t.truthy(err);
+    t.end();
+  });
 });
 
 test.cb('should emit errors on invalid variant', t => {
-    const url = 'http://unleash-test-1-invalid-bariant.app';
-    setup(url, [
+  const url = 'http://unleash-test-1-invalid-bariant.app';
+  setup(url, [
+    {
+      name: 'feature',
+      enabled: true,
+      strategies: [
         {
-            name: 'feature',
-            enabled: true,
-            strategies: [
-                {
-                    name: 'default',
-                },
-            ],
-            variants: 'not legal',
+          name: 'default',
         },
-    ]);
-    const repo = new Repository({
-        backupPath: 'foo',
-        url,
-        appName,
-        instanceId,
-        refreshInterval: 0,
-        StorageImpl: MockStorage,
-    });
+      ],
+      variants: 'not legal',
+    },
+  ]);
+  const repo = new Repository({
+    backupPath: 'foo',
+    url,
+    appName,
+    instanceId,
+    refreshInterval: 0,
+    StorageImpl: MockStorage,
+  });
 
-    repo.once('error', err => {
-        t.truthy(err);
-        t.is(err.message, 'feature.variants should be an array, but was string');
-        t.end();
-    });
+  repo.once('error', err => {
+    t.truthy(err);
+    t.is(err.message, 'feature.variants should be an array, but was string');
+    t.end();
+  });
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,15 +1,20 @@
-import { getAgent } from '../lib/request';
 import test from 'ava';
 
 import * as http from 'http';
 import * as https from 'https';
+import { getAgent, buildHeaders } from '../lib/request';
 
-test('http URLs should yield http.Agent', t => {
-    const agent = getAgent(new URL('http://unleash-host1.com'));
-    t.true(agent instanceof http.Agent);
+test('http URLs should yield http.Agent', (t) => {
+  const agent = getAgent(new URL('http://unleash-host1.com'));
+  t.true(agent instanceof http.Agent);
 });
 
-test('https URLs should yield https.Agent', t => {
-    const agent = getAgent(new URL('https://unleash.hosted.com'));
-    t.true(agent instanceof https.Agent);
+test('https URLs should yield https.Agent', (t) => {
+  const agent = getAgent(new URL('https://unleash.hosted.com'));
+  t.true(agent instanceof https.Agent);
+});
+
+test('Custom headers should be included', (t) => {
+  const headers = buildHeaders('https://bullshit.com', undefined, undefined, undefined, { hello: 'world' });
+  t.is(headers.get('hello'), 'world');
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -86,37 +86,38 @@ test.cb('should emit error when stored data is invalid', (t) => {
   });
 });
 
-test('should not write content from backup file if ready has been fired', (t) => new Promise((resolve, reject) => {
-  const tmp = join(tmpdir(), 'ignore-backup-file-test');
-  mkdirp.sync(tmp);
-  const storage = new Storage({
-    backupPath: tmp,
-    appName: 'test',
-  });
-  const data = { random: Math.random() };
-  storage.on('error', reject);
-
-  storage.once('persisted', () => {
-    t.true(storage.get('random') === data.random);
-
-    const storage2 = new Storage({
+test('should not write content from backup file if ready has been fired',
+  (t) => new Promise((resolve, reject) => {
+    const tmp = join(tmpdir(), 'ignore-backup-file-test');
+    mkdirp.sync(tmp);
+    const storage = new Storage({
       backupPath: tmp,
       appName: 'test',
     });
-    const overwrite = { random: Math.random() };
+    const data = { random: Math.random() };
+    storage.on('error', reject);
 
-    storage2.on('error', reject);
-    storage2.on('ready', () => {
-      t.true(storage2.get('random') !== data.random);
-      t.true(storage2.get('random') === overwrite.random);
-      resolve();
+    storage.once('persisted', () => {
+      t.true(storage.get('random') === data.random);
+
+      const storage2 = new Storage({
+        backupPath: tmp,
+        appName: 'test',
+      });
+      const overwrite = { random: Math.random() };
+
+      storage2.on('error', reject);
+      storage2.on('ready', () => {
+        t.true(storage2.get('random') !== data.random);
+        t.true(storage2.get('random') === overwrite.random);
+        resolve();
+      });
+
+      // Lets pretend "server" finished read first
+      storage2.reset(overwrite);
     });
-
-    // Lets pretend "server" finished read first
-    storage2.reset(overwrite);
-  });
-  storage.reset(data);
-}));
+    storage.reset(data);
+  }));
 
 test('should provide Get method from data', (t) => {
   const storage = setup('get-method');

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -2,184 +2,179 @@ import test from 'ava';
 import { writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { Storage } from '../lib/storage';
 import * as mkdirp from 'mkdirp';
+import { Storage } from '../lib/storage';
 
 function setup(name) {
-    const tmp = join(tmpdir(), name + Math.round(10000 * Math.random()));
-    mkdirp.sync(tmp);
-    const storage = new Storage({ backupPath: tmp, appName: 'test' });
+  const tmp = join(tmpdir(), name + Math.round(10000 * Math.random()));
+  mkdirp.sync(tmp);
+  const storage = new Storage({ backupPath: tmp, appName: 'test' });
 
-    storage.on('error', err => {
-        throw err;
-    });
-    return storage;
+  storage.on('error', (err) => {
+    throw err;
+  });
+  return storage;
 }
 
-test('should load content from backup file', t =>
-    new Promise((resolve, reject) => {
-        const tmp = join(tmpdir(), 'backup-file-test');
-        mkdirp.sync(tmp);
-        const storage = new Storage({ backupPath: tmp, appName: 'test' });
-        const data = { random: Math.random() };
-        storage.on('error', reject);
+test('should load content from backup file', (t) => new Promise((resolve, reject) => {
+  const tmp = join(tmpdir(), 'backup-file-test');
+  mkdirp.sync(tmp);
+  const storage = new Storage({ backupPath: tmp, appName: 'test' });
+  const data = { random: Math.random() };
+  storage.on('error', reject);
 
-        storage.once('persisted', () => {
-            t.true(storage.get('random') === data.random);
+  storage.once('persisted', () => {
+    t.true(storage.get('random') === data.random);
 
-            const storage2 = new Storage({ backupPath: tmp, appName: 'test' });
-            storage2.on('error', reject);
-            storage2.on('ready', () => {
-                t.true(storage2.get('random') === data.random);
-                resolve();
-            });
-        });
-        storage.reset(data);
-    }));
-
-test('should handle complex appNames', t =>
-    new Promise((resolve, reject) => {
-        const tmp = join(tmpdir(), 'backup-file-test');
-        mkdirp.sync(tmp);
-        const appName = '@namspace-dash/slash-some-app';
-        const storage = new Storage({ backupPath: tmp, appName });
-        const data = { random: Math.random() };
-        storage.on('error', reject);
-
-        storage.once('persisted', () => {
-            t.true(storage.get('random') === data.random);
-
-            const storage2 = new Storage({ backupPath: tmp, appName });
-            storage2.on('error', reject);
-            storage2.on('ready', () => {
-                t.true(storage2.get('random') === data.random);
-                resolve();
-            });
-        });
-        storage.reset(data);
-    }));
-
-test.cb('should emit error when non-existent target backupPath', t => {
-    const storage = new Storage({
-        backupPath: join(tmpdir(), `random-${Math.round(Math.random() * 10000)}`),
-        appName: 'test',
+    const storage2 = new Storage({ backupPath: tmp, appName: 'test' });
+    storage2.on('error', reject);
+    storage2.on('ready', () => {
+      t.true(storage2.get('random') === data.random);
+      resolve();
     });
-    storage.reset({ random: Math.random() });
-    storage.on('error', err => {
-        t.truthy(err);
-        t.true(err.code === 'ENOENT');
-        t.end();
+  });
+  storage.reset(data);
+}));
+
+test('should handle complex appNames', (t) => new Promise((resolve, reject) => {
+  const tmp = join(tmpdir(), 'backup-file-test');
+  mkdirp.sync(tmp);
+  const appName = '@namspace-dash/slash-some-app';
+  const storage = new Storage({ backupPath: tmp, appName });
+  const data = { random: Math.random() };
+  storage.on('error', reject);
+
+  storage.once('persisted', () => {
+    t.true(storage.get('random') === data.random);
+
+    const storage2 = new Storage({ backupPath: tmp, appName });
+    storage2.on('error', reject);
+    storage2.on('ready', () => {
+      t.true(storage2.get('random') === data.random);
+      resolve();
     });
+  });
+  storage.reset(data);
+}));
+
+test.cb('should emit error when non-existent target backupPath', (t) => {
+  const storage = new Storage({
+    backupPath: join(tmpdir(), `random-${Math.round(Math.random() * 10000)}`),
+    appName: 'test',
+  });
+  storage.reset({ random: Math.random() });
+  storage.on('error', (err) => {
+    t.truthy(err);
+    t.true(err.code === 'ENOENT');
+    t.end();
+  });
 });
 
-test.cb('should emit error when stored data is invalid', t => {
-    const dir = join(tmpdir(), `random-${Math.round(Math.random() * 10123000)}`);
-    mkdirp.sync(dir);
-    writeFileSync(join(dir, 'unleash-repo-schema-v1-test.json'), '{invalid: json, asd}', 'utf8');
-    const storage = new Storage({
-        backupPath: dir,
-        appName: 'test',
+test.cb('should emit error when stored data is invalid', (t) => {
+  const dir = join(tmpdir(), `random-${Math.round(Math.random() * 10123000)}`);
+  mkdirp.sync(dir);
+  writeFileSync(join(dir, 'unleash-repo-schema-v1-test.json'), '{invalid: json, asd}', 'utf8');
+  const storage = new Storage({
+    backupPath: dir,
+    appName: 'test',
+  });
+  storage.on('persisted', console.log);
+  storage.on('error', (err) => {
+    t.truthy(err);
+    t.regex(err.message, /Unexpected token/);
+    t.end();
+  });
+});
+
+test('should not write content from backup file if ready has been fired', (t) => new Promise((resolve, reject) => {
+  const tmp = join(tmpdir(), 'ignore-backup-file-test');
+  mkdirp.sync(tmp);
+  const storage = new Storage({
+    backupPath: tmp,
+    appName: 'test',
+  });
+  const data = { random: Math.random() };
+  storage.on('error', reject);
+
+  storage.once('persisted', () => {
+    t.true(storage.get('random') === data.random);
+
+    const storage2 = new Storage({
+      backupPath: tmp,
+      appName: 'test',
     });
-    storage.on('persisted', console.log);
-    storage.on('error', err => {
-        t.truthy(err);
-        t.regex(err.message, /Unexpected token/);
-        t.end();
+    const overwrite = { random: Math.random() };
+
+    storage2.on('error', reject);
+    storage2.on('ready', () => {
+      t.true(storage2.get('random') !== data.random);
+      t.true(storage2.get('random') === overwrite.random);
+      resolve();
     });
+
+    // Lets pretend "server" finished read first
+    storage2.reset(overwrite);
+  });
+  storage.reset(data);
+}));
+
+test('should provide Get method from data', (t) => {
+  const storage = setup('get-method');
+  const result = storage.get('some-key');
+
+  t.true(result === undefined);
+
+  storage.reset({ 'some-key': 'some-value' });
+
+  const result2 = storage.get('some-key');
+
+  t.true(result2 === 'some-value');
 });
 
-test('should not write content from backup file if ready has been fired', t =>
-    new Promise((resolve, reject) => {
-        const tmp = join(tmpdir(), 'ignore-backup-file-test');
-        mkdirp.sync(tmp);
-        const storage = new Storage({
-            backupPath: tmp,
-            appName: 'test',
-        });
-        const data = { random: Math.random() };
-        storage.on('error', reject);
+test('should provide getAll method for data object', (t) => {
+  const storage = setup('get-all-method');
+  const result = storage.getAll();
 
-        storage.once('persisted', () => {
-            t.true(storage.get('random') === data.random);
+  t.deepEqual(result, {});
 
-            const storage2 = new Storage({
-                backupPath: tmp,
-                appName: 'test',
-            });
-            const overwrite = { random: Math.random() };
+  storage.reset({ 'some-key': 'some-value' });
 
-            storage2.on('error', reject);
-            storage2.on('ready', () => {
-                t.true(storage2.get('random') !== data.random);
-                t.true(storage2.get('random') === overwrite.random);
-                resolve();
-            });
+  const result2 = storage.getAll();
 
-            // Lets pretend "server" finished read first
-            storage2.reset(overwrite);
-        });
-        storage.reset(data);
-    }));
-
-test('should provide Get method from data', t => {
-    const storage = setup('get-method');
-    const result = storage.get('some-key');
-
-    t.true(result === undefined);
-
-    storage.reset({ 'some-key': 'some-value' });
-
-    const result2 = storage.get('some-key');
-
-    t.true(result2 === 'some-value');
+  t.deepEqual(result2, { 'some-key': 'some-value' });
 });
 
-test('should provide getAll method for data object', t => {
-    const storage = setup('get-all-method');
-    const result = storage.getAll();
+test('should persist data on reset', (t) => new Promise((resolve) => {
+  const storage = setup('persist');
+  const data = { random: Math.random() };
 
-    t.deepEqual(result, {});
+  storage.once('persisted', () => {
+    t.true(storage.get('random') === data.random);
+    resolve();
+  });
 
-    storage.reset({ 'some-key': 'some-value' });
+  t.true(storage.get('random') !== data.random);
+  storage.reset(data);
+  t.true(storage.get('random') === data.random);
+}));
 
-    const result2 = storage.getAll();
+test('should persist again after data reset', (t) => new Promise((resolve) => {
+  const storage = setup('persist2');
+  const data = { random: Math.random() };
 
-    t.deepEqual(result2, { 'some-key': 'some-value' });
-});
+  storage.once('persisted', () => {
+    t.true(storage.get('random') === data.random);
+    const data2 = { random: Math.random() };
 
-test('should persist data on reset', t =>
-    new Promise(resolve => {
-        const storage = setup('persist');
-        const data = { random: Math.random() };
+    storage.once('persisted', () => {
+      t.true(storage.get('random') === data2.random);
+      resolve();
+    });
 
-        storage.once('persisted', () => {
-            t.true(storage.get('random') === data.random);
-            resolve();
-        });
+    storage.reset(data2);
+  });
 
-        t.true(storage.get('random') !== data.random);
-        storage.reset(data);
-        t.true(storage.get('random') === data.random);
-    }));
-
-test('should persist again after data reset', t =>
-    new Promise(resolve => {
-        const storage = setup('persist2');
-        const data = { random: Math.random() };
-
-        storage.once('persisted', () => {
-            t.true(storage.get('random') === data.random);
-            const data2 = { random: Math.random() };
-
-            storage.once('persisted', () => {
-                t.true(storage.get('random') === data2.random);
-                resolve();
-            });
-
-            storage.reset(data2);
-        });
-
-        t.true(storage.get('random') !== data.random);
-        storage.reset(data);
-        t.true(storage.get('random') === data.random);
-    }));
+  t.true(storage.get('random') !== data.random);
+  storage.reset(data);
+  t.true(storage.get('random') === data.random);
+}));

--- a/test/strategy/application-hostname-strategy.test.js
+++ b/test/strategy/application-hostname-strategy.test.js
@@ -1,43 +1,43 @@
 import test from 'ava';
 import { hostname } from 'os';
 
-import { ApplicationHostnameStrategy } from '../../lib/strategy/application-hostname-strategy';
+import ApplicationHostnameStrategy from '../../lib/strategy/application-hostname-strategy';
 
-test('strategy should have correct name', t => {
-    const strategy = new ApplicationHostnameStrategy();
-    t.deepEqual(strategy.name, 'applicationHostname');
+test('strategy should have correct name', (t) => {
+  const strategy = new ApplicationHostnameStrategy();
+  t.deepEqual(strategy.name, 'applicationHostname');
 });
 
-test('strategy should be disabled when no hostname defined', t => {
-    const strategy = new ApplicationHostnameStrategy();
-    const context = { hostNames: '' };
-    t.false(strategy.isEnabled(context));
+test('strategy should be disabled when no hostname defined', (t) => {
+  const strategy = new ApplicationHostnameStrategy();
+  const context = { hostNames: '' };
+  t.false(strategy.isEnabled(context));
 });
 
-test('strategy should be enabled when hostname is defined', t => {
-    process.env.HOSTNAME = '';
-    const strategy = new ApplicationHostnameStrategy();
-    const context = { hostNames: hostname() };
-    t.true(strategy.isEnabled(context));
+test('strategy should be enabled when hostname is defined', (t) => {
+  process.env.HOSTNAME = '';
+  const strategy = new ApplicationHostnameStrategy();
+  const context = { hostNames: hostname() };
+  t.true(strategy.isEnabled(context));
 });
 
-test('strategy should be enabled when hostname is defined in list', t => {
-    process.env.HOSTNAME = '';
-    const strategy = new ApplicationHostnameStrategy();
-    const context = { hostNames: `localhost, ${hostname()}` };
-    t.true(strategy.isEnabled(context));
+test('strategy should be enabled when hostname is defined in list', (t) => {
+  process.env.HOSTNAME = '';
+  const strategy = new ApplicationHostnameStrategy();
+  const context = { hostNames: `localhost, ${hostname()}` };
+  t.true(strategy.isEnabled(context));
 });
 
-test('strategy should be enabled when hostname is defined via env', t => {
-    process.env.HOSTNAME = 'some-random-name';
-    const strategy = new ApplicationHostnameStrategy();
-    const context = { hostNames: 'localhost, some-random-name' };
-    t.true(strategy.isEnabled(context));
+test('strategy should be enabled when hostname is defined via env', (t) => {
+  process.env.HOSTNAME = 'some-random-name';
+  const strategy = new ApplicationHostnameStrategy();
+  const context = { hostNames: 'localhost, some-random-name' };
+  t.true(strategy.isEnabled(context));
 });
 
-test('strategy should handle wierd casing', t => {
-    process.env.HOSTNAME = 'some-random-NAME';
-    const strategy = new ApplicationHostnameStrategy();
-    const context = { hostNames: 'localhost, some-random-name' };
-    t.true(strategy.isEnabled(context));
+test('strategy should handle wierd casing', (t) => {
+  process.env.HOSTNAME = 'some-random-NAME';
+  const strategy = new ApplicationHostnameStrategy();
+  const context = { hostNames: 'localhost, some-random-name' };
+  t.true(strategy.isEnabled(context));
 });

--- a/test/strategy/default-strategy.test.js
+++ b/test/strategy/default-strategy.test.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 
-import { DefaultStrategy } from '../../lib/strategy/default-strategy';
+import DefaultStrategy from '../../lib/strategy/default-strategy';
 
-test('default strategy should be enabled', t => {
-    const strategy = new DefaultStrategy();
-    t.true(strategy.isEnabled());
+test('default strategy should be enabled', (t) => {
+  const strategy = new DefaultStrategy();
+  t.true(strategy.isEnabled());
 });
 
-test('default strategy should have correct name', t => {
-    const strategy = new DefaultStrategy();
-    t.true(strategy.name === 'default');
+test('default strategy should have correct name', (t) => {
+  const strategy = new DefaultStrategy();
+  t.true(strategy.name === 'default');
 });

--- a/test/strategy/flexible-rollout-test.js
+++ b/test/strategy/flexible-rollout-test.js
@@ -48,23 +48,23 @@ test('should NOT be enabled for rollout=10% when userId is 123', (t) => {
 });
 
 test('should be disabled when stickiness=customerId and customerId not found on context', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = {
-        rollout: '100',
-        stickiness: 'customerId',
-        groupId: 'Demo',
-    };
-    const context = {};
-    t.false(strategy.isEnabled(params, context));
+  const strategy = new FlexibleRolloutStrategy();
+  const params = {
+    rollout: '100',
+    stickiness: 'customerId',
+    groupId: 'Demo',
+  };
+  const context = {};
+  t.false(strategy.isEnabled(params, context));
 });
 
 test('should be enabled when stickiness=customerId and customerId=61', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = {
-        rollout: '100',
-        stickiness: 'customerId',
-        groupId: 'Demo',
-    };
-    const context = { customerId: 61 };
-    t.true(strategy.isEnabled(params, context));
+  const strategy = new FlexibleRolloutStrategy();
+  const params = {
+    rollout: '100',
+    stickiness: 'customerId',
+    groupId: 'Demo',
+  };
+  const context = { customerId: 61 };
+  t.true(strategy.isEnabled(params, context));
 });

--- a/test/strategy/flexible-rollout-test.js
+++ b/test/strategy/flexible-rollout-test.js
@@ -1,50 +1,50 @@
 import test from 'ava';
 import sinon from 'sinon';
 
-import { FlexibleRolloutStrategy } from '../../lib/strategy/flexible-rollout-strategy';
+import FlexibleRolloutStrategy from '../../lib/strategy/flexible-rollout-strategy';
 
-test('should have correct name', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    t.deepEqual(strategy.name, 'flexibleRollout');
+test('should have correct name', (t) => {
+  const strategy = new FlexibleRolloutStrategy();
+  t.deepEqual(strategy.name, 'flexibleRollout');
 });
 
-test('should NOT be enabled for userId=61 and rollout=9', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = { rollout: 9, stickiness: 'default', groupId: 'Demo' };
-    const context = { userId: '61', application: 'web' };
-    t.false(strategy.isEnabled(params, context));
+test('should NOT be enabled for userId=61 and rollout=9', (t) => {
+  const strategy = new FlexibleRolloutStrategy();
+  const params = { rollout: 9, stickiness: 'default', groupId: 'Demo' };
+  const context = { userId: '61', application: 'web' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should be enabled for userId=61 and rollout=10', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = { rollout: '10', stickiness: 'default', groupId: 'Demo' };
-    const context = { userId: '61', application: 'web' };
-    t.true(strategy.isEnabled(params, context));
+test('should be enabled for userId=61 and rollout=10', (t) => {
+  const strategy = new FlexibleRolloutStrategy();
+  const params = { rollout: '10', stickiness: 'default', groupId: 'Demo' };
+  const context = { userId: '61', application: 'web' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when stickiness=userId and userId not on context', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = { rollout: '100', stickiness: 'userId', groupId: 'Demo' };
-    const context = {};
-    t.false(strategy.isEnabled(params, context));
+test('should be disabled when stickiness=userId and userId not on context', (t) => {
+  const strategy = new FlexibleRolloutStrategy();
+  const params = { rollout: '100', stickiness: 'userId', groupId: 'Demo' };
+  const context = {};
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should fallback to random if stickiness=default and empty context', t => {
-    const randomGenerator = sinon.fake.returns('42');
+test('should fallback to random if stickiness=default and empty context', (t) => {
+  const randomGenerator = sinon.fake.returns('42');
 
-    const strategy = new FlexibleRolloutStrategy(randomGenerator);
-    const params = { rollout: '100', stickiness: 'default', groupId: 'Demo' };
-    const context = {};
+  const strategy = new FlexibleRolloutStrategy(randomGenerator);
+  const params = { rollout: '100', stickiness: 'default', groupId: 'Demo' };
+  const context = {};
 
-    t.true(strategy.isEnabled(params, context));
-    t.true(randomGenerator.called);
+  t.true(strategy.isEnabled(params, context));
+  t.true(randomGenerator.called);
 });
 
-test('should NOT be enabled for rollout=10% when userId is 123', t => {
-    const strategy = new FlexibleRolloutStrategy();
-    const params = { rollout: 10, stickiness: 'default', groupId: 'toggleName' };
-    const context = { environment: 'dev', userId: '123' };
-    t.false(strategy.isEnabled(params, context));
+test('should NOT be enabled for rollout=10% when userId is 123', (t) => {
+  const strategy = new FlexibleRolloutStrategy();
+  const params = { rollout: 10, stickiness: 'default', groupId: 'toggleName' };
+  const context = { environment: 'dev', userId: '123' };
+  t.false(strategy.isEnabled(params, context));
 });
 
 test('should be disabled when stickiness=customerId and customerId not found on context', t => {

--- a/test/strategy/gradual-rollout-random.test.js
+++ b/test/strategy/gradual-rollout-random.test.js
@@ -1,68 +1,68 @@
 import test from 'ava';
 
-import { GradualRolloutRandomStrategy } from '../../lib/strategy/gradual-rollout-random';
+import GradualRolloutRandomStrategy from '../../lib/strategy/gradual-rollout-random';
 
-test('should have correct name', t => {
-    const strategy = new GradualRolloutRandomStrategy();
-    t.deepEqual(strategy.name, 'gradualRolloutRandom');
+test('should have correct name', (t) => {
+  const strategy = new GradualRolloutRandomStrategy();
+  t.deepEqual(strategy.name, 'gradualRolloutRandom');
 });
 
-test('should only at most miss by one percent', t => {
-    const strategy = new GradualRolloutRandomStrategy();
+test('should only at most miss by one percent', (t) => {
+  const strategy = new GradualRolloutRandomStrategy();
 
-    const percentage = 25;
-    const groupId = 'groupId';
+  const percentage = 25;
+  const groupId = 'groupId';
 
-    const rounds = 200000;
-    let enabledCount = 0;
+  const rounds = 200000;
+  let enabledCount = 0;
 
-    for (let i = 0; i < rounds; i++) {
-        let params = { percentage, groupId };
-        let context = { sessionId: i };
-        if (strategy.isEnabled(params, context)) {
-            enabledCount++;
-        }
+  for (let i = 0; i < rounds; i++) {
+    const params = { percentage, groupId };
+    const context = { sessionId: i };
+    if (strategy.isEnabled(params, context)) {
+      enabledCount++;
     }
-    const actualPercentage = Math.round((enabledCount / rounds) * 100);
-    const highMark = percentage + 1;
-    const lowMark = percentage - 1;
+  }
+  const actualPercentage = Math.round((enabledCount / rounds) * 100);
+  const highMark = percentage + 1;
+  const lowMark = percentage - 1;
 
-    t.true(lowMark <= actualPercentage);
-    t.true(highMark >= actualPercentage);
+  t.true(lowMark <= actualPercentage);
+  t.true(highMark >= actualPercentage);
 });
 
-test('should be disabled when percentage is lower than random', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 50);
-    let params = { percentage: '20', groupId: 'test' };
-    t.false(strategy.isEnabled(params));
+test('should be disabled when percentage is lower than random', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 50);
+  const params = { percentage: '20', groupId: 'test' };
+  t.false(strategy.isEnabled(params));
 });
 
-test('should be disabled when percentage=0', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 1);
-    let params = { percentage: '0', groupId: 'test' };
-    t.false(strategy.isEnabled(params));
+test('should be disabled when percentage=0', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 1);
+  const params = { percentage: '0', groupId: 'test' };
+  t.false(strategy.isEnabled(params));
 });
 
-test('should be disabled when percentage=0 and random is not zero', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 50);
-    let params = { percentage: '0', groupId: 'test' };
-    t.false(strategy.isEnabled(params));
+test('should be disabled when percentage=0 and random is not zero', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 50);
+  const params = { percentage: '0', groupId: 'test' };
+  t.false(strategy.isEnabled(params));
 });
 
-test('should be enabled when percentage is greater than random', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 10);
-    let params = { percentage: '20', groupId: 'test' };
-    t.true(strategy.isEnabled(params));
+test('should be enabled when percentage is greater than random', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 10);
+  const params = { percentage: '20', groupId: 'test' };
+  t.true(strategy.isEnabled(params));
 });
 
-test('should be enabled when percentage=100', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 90);
-    let params = { percentage: '100', groupId: 'test' };
-    t.true(strategy.isEnabled(params));
+test('should be enabled when percentage=100', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 90);
+  const params = { percentage: '100', groupId: 'test' };
+  t.true(strategy.isEnabled(params));
 });
 
-test('should be enabled when percentage and random are the same', t => {
-    const strategy = new GradualRolloutRandomStrategy(() => 55);
-    let params = { percentage: '55', groupId: 'test' };
-    t.true(strategy.isEnabled(params));
+test('should be enabled when percentage and random are the same', (t) => {
+  const strategy = new GradualRolloutRandomStrategy(() => 55);
+  const params = { percentage: '55', groupId: 'test' };
+  t.true(strategy.isEnabled(params));
 });

--- a/test/strategy/gradual-rollout-session-id.test.js
+++ b/test/strategy/gradual-rollout-session-id.test.js
@@ -1,69 +1,69 @@
 import test from 'ava';
 
-import { GradualRolloutSessionIdStrategy } from '../../lib/strategy/gradual-rollout-session-id';
-import { normalizedValue } from '../../lib/strategy/util';
+import GradualRolloutSessionIdStrategy from '../../lib/strategy/gradual-rollout-session-id';
+import normalizedValue from '../../lib/strategy/util';
 
-test('gradual-rollout-user-id strategy should have correct name', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
-    t.deepEqual(strategy.name, 'gradualRolloutSessionId');
+test('gradual-rollout-user-id strategy should have correct name', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
+  t.deepEqual(strategy.name, 'gradualRolloutSessionId');
 });
 
-test('should be enabled when percentage is 100', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
-    const params = { percentage: '100', groupId: 'gr1' };
-    const context = { sessionId: '123' };
-    t.true(strategy.isEnabled(params, context));
+test('should be enabled when percentage is 100', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
+  const params = { percentage: '100', groupId: 'gr1' };
+  const context = { sessionId: '123' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when percentage is 0', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
-    const params = { percentage: '0', groupId: 'gr1' };
-    const context = { sessionId: '123' };
-    t.false(strategy.isEnabled(params, context));
+test('should be disabled when percentage is 0', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
+  const params = { percentage: '0', groupId: 'gr1' };
+  const context = { sessionId: '123' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should be enabled when percentage is exactly same', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
-    const sessionId = '123123';
-    const groupId = 'group1';
+test('should be enabled when percentage is exactly same', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
+  const sessionId = '123123';
+  const groupId = 'group1';
 
-    const percentage = normalizedValue(sessionId, groupId);
-    const params = { percentage: `${percentage}`, groupId };
-    const context = { sessionId };
-    t.true(strategy.isEnabled(params, context));
+  const percentage = normalizedValue(sessionId, groupId);
+  const params = { percentage: `${percentage}`, groupId };
+  const context = { sessionId };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when percentage is just below required value', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
-    const sessionId = '123123';
-    const groupId = 'group1';
+test('should be disabled when percentage is just below required value', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
+  const sessionId = '123123';
+  const groupId = 'group1';
 
-    const percentage = normalizedValue(sessionId, groupId) - 1;
-    const params = { percentage: `${percentage}`, groupId };
-    const context = { sessionId };
-    t.false(strategy.isEnabled(params, context));
+  const percentage = normalizedValue(sessionId, groupId) - 1;
+  const params = { percentage: `${percentage}`, groupId };
+  const context = { sessionId };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should only at most miss by one percent', t => {
-    const strategy = new GradualRolloutSessionIdStrategy();
+test('should only at most miss by one percent', (t) => {
+  const strategy = new GradualRolloutSessionIdStrategy();
 
-    const percentage = 25;
-    const groupId = 'groupId';
+  const percentage = 25;
+  const groupId = 'groupId';
 
-    const rounds = 200000;
-    let enabledCount = 0;
+  const rounds = 200000;
+  let enabledCount = 0;
 
-    for (let i = 0; i < rounds; i++) {
-        let params = { percentage, groupId };
-        let context = { sessionId: i };
-        if (strategy.isEnabled(params, context)) {
-            enabledCount++;
-        }
+  for (let i = 0; i < rounds; i++) {
+    const params = { percentage, groupId };
+    const context = { sessionId: i };
+    if (strategy.isEnabled(params, context)) {
+      enabledCount++;
     }
-    const actualPercentage = Math.round((enabledCount / rounds) * 100);
-    const highMark = percentage + 1;
-    const lowMark = percentage - 1;
+  }
+  const actualPercentage = Math.round((enabledCount / rounds) * 100);
+  const highMark = percentage + 1;
+  const lowMark = percentage - 1;
 
-    t.true(lowMark <= actualPercentage);
-    t.true(highMark >= actualPercentage);
+  t.true(lowMark <= actualPercentage);
+  t.true(highMark >= actualPercentage);
 });

--- a/test/strategy/gradual-rollout-user-id.test.js
+++ b/test/strategy/gradual-rollout-user-id.test.js
@@ -1,69 +1,69 @@
 import test from 'ava';
 
-import { GradualRolloutUserIdStrategy } from '../../lib/strategy/gradual-rollout-user-id';
-import { normalizedValue } from '../../lib/strategy/util';
+import GradualRolloutUserIdStrategy from '../../lib/strategy/gradual-rollout-user-id';
+import normalizedValue from '../../lib/strategy/util';
 
-test('gradual-rollout-user-id strategy should have correct name', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
-    t.deepEqual(strategy.name, 'gradualRolloutUserId');
+test('gradual-rollout-user-id strategy should have correct name', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
+  t.deepEqual(strategy.name, 'gradualRolloutUserId');
 });
 
-test('should be enabled when percentage is 100', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
-    const params = { percentage: '100', groupId: 'gr1' };
-    const context = { userId: '123' };
-    t.true(strategy.isEnabled(params, context));
+test('should be enabled when percentage is 100', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
+  const params = { percentage: '100', groupId: 'gr1' };
+  const context = { userId: '123' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when percentage is 0', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
-    const params = { percentage: '0', groupId: 'gr1' };
-    const context = { userId: '123' };
-    t.false(strategy.isEnabled(params, context));
+test('should be disabled when percentage is 0', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
+  const params = { percentage: '0', groupId: 'gr1' };
+  const context = { userId: '123' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should be enabled when percentage is exactly same', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
-    const userId = '123123';
-    const groupId = 'group1';
+test('should be enabled when percentage is exactly same', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
+  const userId = '123123';
+  const groupId = 'group1';
 
-    const percentage = normalizedValue(userId, groupId);
-    const params = { percentage: `${percentage}`, groupId };
-    const context = { userId };
-    t.true(strategy.isEnabled(params, context));
+  const percentage = normalizedValue(userId, groupId);
+  const params = { percentage: `${percentage}`, groupId };
+  const context = { userId };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('should be disabled when percentage is just below required value', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
-    const userId = '123123';
-    const groupId = 'group1';
+test('should be disabled when percentage is just below required value', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
+  const userId = '123123';
+  const groupId = 'group1';
 
-    const percentage = normalizedValue(userId, groupId) - 1;
-    const params = { percentage: `${percentage}`, groupId };
-    const context = { userId };
-    t.false(strategy.isEnabled(params, context));
+  const percentage = normalizedValue(userId, groupId) - 1;
+  const params = { percentage: `${percentage}`, groupId };
+  const context = { userId };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('should only at most miss by one percent', t => {
-    const strategy = new GradualRolloutUserIdStrategy();
+test('should only at most miss by one percent', (t) => {
+  const strategy = new GradualRolloutUserIdStrategy();
 
-    const percentage = 10;
-    const groupId = 'groupId';
+  const percentage = 10;
+  const groupId = 'groupId';
 
-    const rounds = 200000;
-    let enabledCount = 0;
+  const rounds = 200000;
+  let enabledCount = 0;
 
-    for (let i = 0; i < rounds; i++) {
-        let params = { percentage, groupId };
-        let context = { userId: i };
-        if (strategy.isEnabled(params, context)) {
-            enabledCount++;
-        }
+  for (let i = 0; i < rounds; i++) {
+    const params = { percentage, groupId };
+    const context = { userId: i };
+    if (strategy.isEnabled(params, context)) {
+      enabledCount++;
     }
-    const actualPercentage = Math.round((enabledCount / rounds) * 100);
-    const highMark = percentage + 1;
-    const lowMark = percentage - 1;
+  }
+  const actualPercentage = Math.round((enabledCount / rounds) * 100);
+  const highMark = percentage + 1;
+  const lowMark = percentage - 1;
 
-    t.true(lowMark <= actualPercentage);
-    t.true(highMark >= actualPercentage);
+  t.true(lowMark <= actualPercentage);
+  t.true(highMark >= actualPercentage);
 });

--- a/test/strategy/remote-address-strategy.test.js
+++ b/test/strategy/remote-address-strategy.test.js
@@ -1,57 +1,57 @@
 import test from 'ava';
 
-import { RemoteAddressStrategy } from '../../lib/strategy/remote-addresss-strategy';
+import RemoteAddressStrategy from '../../lib/strategy/remote-addresss-strategy';
 
-test('strategy should have correct name', t => {
-    const strategy = new RemoteAddressStrategy();
-    t.deepEqual(strategy.name, 'remoteAddress');
+test('strategy should have correct name', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  t.deepEqual(strategy.name, 'remoteAddress');
 });
 
-test('RemoteAddressStrategy should not crash for missing params', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = {};
-    const context = { remoteAddress: '123' };
-    t.false(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should not crash for missing params', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = {};
+  const context = { remoteAddress: '123' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should be enabled for ip in list (localhost)', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.0.0.1' };
-    const context = { remoteAddress: '127.0.0.1' };
-    t.true(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should be enabled for ip in list (localhost)', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.0.0.1' };
+  const context = { remoteAddress: '127.0.0.1' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should not be enabled for ip NOT in list', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.0.1.1, 127.0.1.2, 127.0.1.3' };
-    const context = { remoteAddress: '127.0.1.5' };
-    t.false(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should not be enabled for ip NOT in list', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.0.1.1, 127.0.1.2, 127.0.1.3' };
+  const context = { remoteAddress: '127.0.1.5' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should be enabled for ip in list', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3' };
-    const context = { remoteAddress: '127.0.1.2' };
-    t.true(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should be enabled for ip in list', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3' };
+  const context = { remoteAddress: '127.0.1.2' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should be enabled for ip inside range in a list', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3, 160.33.0.0/16' };
-    const context = { remoteAddress: '160.33.0.33' };
-    t.true(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should be enabled for ip inside range in a list', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.0.1.1, 127.0.1.2,127.0.1.3, 160.33.0.0/16' };
+  const context = { remoteAddress: '160.33.0.33' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should handle invalid IPs', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.invalid' };
-    const context = { remoteAddress: '127.0.0.1' };
-    t.false(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should handle invalid IPs', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.invalid' };
+  const context = { remoteAddress: '127.0.0.1' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('RemoteAddressStrategy should ignore invalid IPs', t => {
-    const strategy = new RemoteAddressStrategy();
-    const params = { IPs: '127.0.0.2, 127.invalid, 127.0.0.1' };
-    const context = { remoteAddress: '127.0.0.1' };
-    t.true(strategy.isEnabled(params, context));
+test('RemoteAddressStrategy should ignore invalid IPs', (t) => {
+  const strategy = new RemoteAddressStrategy();
+  const params = { IPs: '127.0.0.2, 127.invalid, 127.0.0.1' };
+  const context = { remoteAddress: '127.0.0.1' };
+  t.true(strategy.isEnabled(params, context));
 });

--- a/test/strategy/strategy-test.js
+++ b/test/strategy/strategy-test.js
@@ -2,106 +2,106 @@ import test from 'ava';
 
 import { Strategy } from '../../lib/strategy/strategy';
 
-test('should be enabled', t => {
-    const strategy = new Strategy('test', true);
-    t.true(strategy.isEnabled());
+test('should be enabled', (t) => {
+  const strategy = new Strategy('test', true);
+  t.true(strategy.isEnabled());
 });
 
-test('should be enabled for environment=dev', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [{ contextName: 'environment', operator: 'IN', values: ['stage', 'dev'] }];
-    const context = { environment: 'dev' };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should be enabled for environment=dev', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [{ contextName: 'environment', operator: 'IN', values: ['stage', 'dev'] }];
+  const context = { environment: 'dev' };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should NOT be enabled for environment=prod', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [{ contextName: 'environment', operator: 'IN', values: ['dev'] }];
-    const context = { environment: 'prod' };
-    t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should NOT be enabled for environment=prod', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [{ contextName: 'environment', operator: 'IN', values: ['dev'] }];
+  const context = { environment: 'prod' };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should NOT be enabled for environment=prod AND userId=123', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [
-        { contextName: 'environment', operator: 'IN', values: ['dev'] },
-        { contextName: 'userId', operator: 'IN', values: ['123'] },
-    ];
-    const context = { environment: 'prod', userId: '123' };
-    t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should NOT be enabled for environment=prod AND userId=123', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'environment', operator: 'IN', values: ['dev'] },
+    { contextName: 'userId', operator: 'IN', values: ['123'] },
+  ];
+  const context = { environment: 'prod', userId: '123' };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should NOT be enabled for environment=dev and strategy return false', t => {
-    const strategy = new Strategy('test', false);
-    const params = {};
-    const constraints = [{ contextName: 'environment', operator: 'IN', values: ['dev'] }];
-    const context = { environment: 'dev', userId: '123' };
-    t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should NOT be enabled for environment=dev and strategy return false', (t) => {
+  const strategy = new Strategy('test', false);
+  const params = {};
+  const constraints = [{ contextName: 'environment', operator: 'IN', values: ['dev'] }];
+  const context = { environment: 'dev', userId: '123' };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should be enabled when constraints is empty list', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [];
-    const context = { environment: 'dev', userId: '123' };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should be enabled when constraints is empty list', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [];
+  const context = { environment: 'dev', userId: '123' };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should be enabled when constraints is undefined', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = undefined;
-    const context = { environment: 'dev', userId: '123' };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should be enabled when constraints is undefined', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = undefined;
+  const context = { environment: 'dev', userId: '123' };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should be enabled when environment NOT_IN constaints', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [
-        { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
-    ];
-    const context = { environment: 'local', userId: '123' };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should be enabled when environment NOT_IN constaints', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
+  ];
+  const context = { environment: 'local', userId: '123' };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should not enabled for multiple constraints where last one is not satisfied', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [
-        { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
-        { contextName: 'environment', operator: 'IN', values: ['prod'] },
-    ];
-    const context = { environment: 'local', userId: '123' };
-    t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should not enabled for multiple constraints where last one is not satisfied', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
+    { contextName: 'environment', operator: 'IN', values: ['prod'] },
+  ];
+  const context = { environment: 'local', userId: '123' };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should not enabled for multiple constraints where all are satisfied', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [
-        { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
-        { contextName: 'environment', operator: 'IN', values: ['prod'] },
-        { contextName: 'userId', operator: 'IN', values: ['123', '223'] },
-        { contextName: 'appName', operator: 'IN', values: ['web'] },
-    ];
-    const context = { environment: 'prod', userId: '123', appName: 'web' };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should not enabled for multiple constraints where all are satisfied', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'environment', operator: 'NOT_IN', values: ['dev', 'stage'] },
+    { contextName: 'environment', operator: 'IN', values: ['prod'] },
+    { contextName: 'userId', operator: 'IN', values: ['123', '223'] },
+    { contextName: 'appName', operator: 'IN', values: ['web'] },
+  ];
+  const context = { environment: 'prod', userId: '123', appName: 'web' };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should be enabled when cosutomerId is in constraint', t => {
-    const strategy = new Strategy('test', true);
-    const params = {};
-    const constraints = [
-        { contextName: 'environment', operator: 'IN', values: ['dev', 'stage'] },
-        { contextName: 'customer', operator: 'IN', values: ['12', '13'] },
-    ];
-    const context = {
-        environment: 'dev',
-        properties: { customer: '13' },
-    };
-    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+test('should be enabled when cosutomerId is in constraint', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'environment', operator: 'IN', values: ['dev', 'stage'] },
+    { contextName: 'customer', operator: 'IN', values: ['12', '13'] },
+  ];
+  const context = {
+    environment: 'dev',
+    properties: { customer: '13' },
+  };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });

--- a/test/strategy/user-with-id-strategy.test.js
+++ b/test/strategy/user-with-id-strategy.test.js
@@ -1,36 +1,36 @@
 import test from 'ava';
 
-import { UserWithIdStrategy } from '../../lib/strategy/user-with-id-strategy';
+import UserWithIdStrategy from '../../lib/strategy/user-with-id-strategy';
 
-test('default strategy should have correct name', t => {
-    const strategy = new UserWithIdStrategy();
-    t.deepEqual(strategy.name, 'userWithId');
+test('default strategy should have correct name', (t) => {
+  const strategy = new UserWithIdStrategy();
+  t.deepEqual(strategy.name, 'userWithId');
 });
 
-test('user-with-id-strategy should be enabled for userId', t => {
-    const strategy = new UserWithIdStrategy();
-    const params = { userIds: '123' };
-    const context = { userId: '123' };
-    t.true(strategy.isEnabled(params, context));
+test('user-with-id-strategy should be enabled for userId', (t) => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123' };
+  const context = { userId: '123' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('user-with-id-strategy should be enabled for userId in list (spaced commas)', t => {
-    const strategy = new UserWithIdStrategy();
-    const params = { userIds: '123, 122, 12312312' };
-    const context = { userId: '12312312' };
-    t.true(strategy.isEnabled(params, context));
+test('user-with-id-strategy should be enabled for userId in list (spaced commas)', (t) => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123, 122, 12312312' };
+  const context = { userId: '12312312' };
+  t.true(strategy.isEnabled(params, context));
 });
 
-test('user-with-id-strategy should not be enabled for userId NOT in list', t => {
-    const strategy = new UserWithIdStrategy();
-    const params = { userIds: '123, 122, 122' };
-    const context = { userId: '12' };
-    t.false(strategy.isEnabled(params, context));
+test('user-with-id-strategy should not be enabled for userId NOT in list', (t) => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123, 122, 122' };
+  const context = { userId: '12' };
+  t.false(strategy.isEnabled(params, context));
 });
 
-test('user-with-id-strategy should be enabled for userId in list', t => {
-    const strategy = new UserWithIdStrategy();
-    const params = { userIds: '123,122,12312312' };
-    const context = { userId: '122' };
-    t.true(strategy.isEnabled(params, context));
+test('user-with-id-strategy should be enabled for userId in list', (t) => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123,122,12312312' };
+  const context = { userId: '122' };
+  t.true(strategy.isEnabled(params, context));
 });

--- a/test/strategy/util.test.js
+++ b/test/strategy/util.test.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 
-import { normalizedValue } from '../../lib/strategy/util';
+import normalizedValue from '../../lib/strategy/util';
 
-test('normalized values are the same across node, java, and go clients', t => {
-    t.is(normalizedValue('123', 'gr1'), 73);
-    t.is(normalizedValue('999', 'groupX'), 25);
+test('normalized values are the same across node, java, and go clients', (t) => {
+  t.is(normalizedValue('123', 'gr1'), 73);
+  t.is(normalizedValue('999', 'groupX'), 25);
 });

--- a/test/true_custom_strategy.js
+++ b/test/true_custom_strategy.js
@@ -1,0 +1,11 @@
+import { Strategy } from '../lib';
+
+export default class CustomStrategy extends Strategy {
+  constructor() {
+    super('custom');
+  }
+
+  isEnabled() {
+    return true;
+  }
+}

--- a/test/unleash.network.test.js
+++ b/test/unleash.network.test.js
@@ -7,29 +7,29 @@ import { Unleash } from '../lib/unleash';
 test.before(() => nock.disableNetConnect());
 test.after(() => nock.enableNetConnect());
 
-test.cb('should emit network errors', t => {
-    t.plan(3);
-    const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
-    const unleash = new Unleash({
-        appName: 'network',
-        url: 'http://blocked.app',
-        refreshInterval: 20000,
-        metricsInterval: 20000,
-        disableMetrics: false,
-        backupPath,
+test.cb('should emit network errors', (t) => {
+  t.plan(3);
+  const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
+  const unleash = new Unleash({
+    appName: 'network',
+    url: 'http://blocked.app',
+    refreshInterval: 20000,
+    metricsInterval: 20000,
+    disableMetrics: false,
+    backupPath,
+  });
+
+  unleash.on('error', (e) => {
+    t.truthy(e);
+  });
+
+  unleash.isEnabled('some-toggle');
+  unleash.metrics.sendMetrics();
+
+  setTimeout(() => {
+    unleash.destroy();
+    process.nextTick(() => {
+      t.end();
     });
-
-    unleash.on('error', e => {
-        t.truthy(e);
-    });
-
-    unleash.isEnabled('some-toggle');
-    unleash.metrics.sendMetrics();
-
-    setTimeout(() => {
-        unleash.destroy();
-        process.nextTick(() => {
-            t.end();
-        });
-    }, 5);
+  }, 5);
 });

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -3,436 +3,410 @@ import nock from 'nock';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import mkdirp from 'mkdirp';
-import { EventEmitter } from 'events';
 import sinon from 'sinon';
+import FakeRepo from './fake_repo';
 
 import { Strategy, Unleash } from '../lib/unleash';
 
 class EnvironmentStrategy extends Strategy {
-    constructor() {
-        super('EnvironmentStrategy');
-    }
+  constructor() {
+    super('EnvironmentStrategy');
+  }
 
-    isEnabled(parameters, context) {
-        return parameters.environments.indexOf(context.environment) !== -1;
-    }
+  isEnabled(parameters, context) {
+    return parameters.environments.indexOf(context.environment) !== -1;
+  }
 }
 
 let counter = 1;
 const getUrl = () => `http://test2${counter++}.app/`;
 
 function getRandomBackupPath() {
-    const path = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
-    mkdirp.sync(path);
-    return path;
+  const path = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
+  mkdirp.sync(path);
+  return path;
 }
 
 const defaultToggles = [
-    {
-        name: 'feature',
-        enabled: true,
-        strategies: [],
-    },
-    {
-        name: 'f-context',
-        enabled: true,
-        strategies: [
-            {
-                name: 'EnvironmentStrategy',
-                parameters: {
-                    environments: 'prod',
-                },
-            },
-        ],
-    },
+  {
+    name: 'feature',
+    enabled: true,
+    strategies: [],
+  },
+  {
+    name: 'f-context',
+    enabled: true,
+    strategies: [
+      {
+        name: 'EnvironmentStrategy',
+        parameters: {
+          environments: 'prod',
+        },
+      },
+    ],
+  },
 ];
 
-class FakeRepo extends EventEmitter {
-    constructor() {
-        super();
-        this.data = {
-            name: 'fake-feature',
-            enabled: false,
-            strategies: [],
-        };
-    }
-    stop() {
-        return;
-    }
-    getToggle() {
-        return this.data;
-    }
-}
-
 function mockNetwork(toggles = defaultToggles, url = getUrl()) {
-    nock(url)
-        .get('/client/features')
-        .reply(200, { features: toggles });
-    return url;
+  nock(url)
+    .get('/client/features')
+    .reply(200, { features: toggles });
+  return url;
 }
 
-test('should error when missing url', t => {
-    t.throws(() => new Unleash({}));
-    t.throws(() => new Unleash({ url: false }));
-    t.throws(() => new Unleash({ url: 'http://unleash.github.io', appName: false }));
+test('should error when missing url', (t) => {
+  t.throws(() => new Unleash({}));
+  t.throws(() => new Unleash({ url: false }));
+  t.throws(() => new Unleash({ url: 'http://unleash.github.io', appName: false }));
 });
 
-test('calling destroy synchronously should avoid network activity', t => {
-    const url = getUrl();
-    // Don't call mockNetwork. If destroy didn't work, then we would have an
-    // uncaught exception.
-    const instance = new Unleash({
-        appName: 'foo',
-        url,
-        disableMetrics: true,
-    });
+test('calling destroy synchronously should avoid network activity', (t) => {
+  const url = getUrl();
+  // Don't call mockNetwork. If destroy didn't work, then we would have an
+  // uncaught exception.
+  const instance = new Unleash({
+    appName: 'foo',
+    url,
+    disableMetrics: true,
+  });
+  instance.destroy();
+  t.true(true);
+});
+
+test.cb('should handle old url', (t) => {
+  const url = mockNetwork([]);
+
+  const instance = new Unleash({
+    appName: 'foo',
+    refreshInterval: 0,
+    metricsInterval: 0,
+    disableMetrics: true,
+    url: `${url}features`,
+  });
+
+  t.plan(1);
+  instance.on('warn', (e) => {
+    t.truthy(e);
+    t.end();
+  });
+
+  instance.destroy();
+});
+
+test('should handle url without ending /', (t) => {
+  const baseUrl = `${getUrl()}api`;
+
+  mockNetwork([], baseUrl);
+
+  const instance = new Unleash({
+    appName: 'foo',
+    refreshInterval: 0,
+    metricsInterval: 0,
+    disableMetrics: true,
+    url: baseUrl,
+  });
+
+  t.true(`${baseUrl}/` === instance.repository.url);
+
+  instance.destroy();
+});
+
+test('should re-emit error from repository, storage and metrics', (t) => {
+  const url = mockNetwork([]);
+
+  const instance = new Unleash({
+    appName: 'foo',
+    refreshInterval: 0,
+    metricsInterval: 0,
+    disableMetrics: true,
+    url,
+  });
+
+  t.plan(3);
+  instance.on('error', (e) => {
+    t.truthy(e);
+  });
+  instance.repository.emit('error', new Error());
+  instance.repository.storage.emit('error', new Error());
+  instance.metrics.emit('error', new Error());
+
+  instance.destroy();
+});
+
+test('should re-emit events from repository and metrics', (t) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    refreshInterval: 0,
+    disableMetrics: true,
+    url,
+  });
+
+  t.plan(5);
+  instance.on('warn', (e) => t.truthy(e));
+  instance.on('sent', (e) => t.truthy(e));
+  instance.on('registered', (e) => t.truthy(e));
+  instance.on('count', (e) => t.truthy(e));
+
+  instance.repository.emit('warn', true);
+  instance.metrics.emit('warn', true);
+  instance.metrics.emit('sent', true);
+  instance.metrics.emit('registered', true);
+  instance.metrics.emit('count', true);
+
+  instance.destroy();
+});
+
+test.cb('repository should surface error when invalid basePath', (t) => {
+  const url = 'http://unleash-surface.app/';
+  nock(url)
+    .get('/client/features')
+    .delay(100)
+    .reply(200, { features: [] });
+  const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    refreshInterval: 0,
+    url,
+    backupPath,
+  });
+
+  instance.once('error', (err) => {
+    t.truthy(err);
+    t.true(err.code === 'ENOENT');
+
     instance.destroy();
-    t.true(true);
+
+    t.end();
+  });
 });
 
-test.cb('should handle old url', t => {
-    const url = mockNetwork([]);
+test('should allow request even before unleash is initialized', (t) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', (err) => {
+    throw err;
+  });
+  t.true(instance.isEnabled('unknown') === false);
+  instance.destroy();
+});
 
-    const instance = new Unleash({
-        appName: 'foo',
-        refreshInterval: 0,
-        metricsInterval: 0,
-        disableMetrics: true,
-        url: `${url}features`,
-    });
+test('should consider known feature-toggle as active', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-    t.plan(1);
-    instance.on('warn', e => {
-        t.truthy(e);
-        t.end();
-    });
-
+  instance.on('ready', () => {
+    t.true(instance.isEnabled('feature') === true);
     instance.destroy();
-});
+    resolve();
+  });
+}));
 
-test('should handle url without ending /', t => {
-    const baseUrl = `${getUrl()}api`;
+test('should consider unknown feature-toggle as disabled', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-    mockNetwork([], baseUrl);
-
-    const instance = new Unleash({
-        appName: 'foo',
-        refreshInterval: 0,
-        metricsInterval: 0,
-        disableMetrics: true,
-        url: baseUrl,
-    });
-
-    t.true(`${baseUrl}/` === instance.repository.url);
-
-    instance.destroy();
-});
-
-test('should re-emit error from repository, storage and metrics', t => {
-    const url = mockNetwork([]);
-
-    const instance = new Unleash({
-        appName: 'foo',
-        refreshInterval: 0,
-        metricsInterval: 0,
-        disableMetrics: true,
-        url,
-    });
-
-    t.plan(3);
-    instance.on('error', e => {
-        t.truthy(e);
-    });
-    instance.repository.emit('error', new Error());
-    instance.repository.storage.emit('error', new Error());
-    instance.metrics.emit('error', new Error());
-
-    instance.destroy();
-});
-
-test('should re-emit events from repository and metrics', t => {
-    const url = mockNetwork();
-    const instance = new Unleash({
-        appName: 'foo',
-        refreshInterval: 0,
-        disableMetrics: true,
-        url,
-    });
-
-    t.plan(5);
-    instance.on('warn', e => t.truthy(e));
-    instance.on('sent', e => t.truthy(e));
-    instance.on('registered', e => t.truthy(e));
-    instance.on('count', e => t.truthy(e));
-
-    instance.repository.emit('warn', true);
-    instance.metrics.emit('warn', true);
-    instance.metrics.emit('sent', true);
-    instance.metrics.emit('registered', true);
-    instance.metrics.emit('count', true);
-
-    instance.destroy();
-});
-
-test.cb('repository should surface error when invalid basePath', t => {
-    const url = 'http://unleash-surface.app/';
-    nock(url)
-        .get('/client/features')
-        .delay(100)
-        .reply(200, { features: [] });
-    const backupPath = join(tmpdir(), `test-tmp-${Math.round(Math.random() * 100000)}`);
-    const instance = new Unleash({
-        appName: 'foo',
-        disableMetrics: true,
-        refreshInterval: 0,
-        url,
-        backupPath,
-    });
-
-    instance.once('error', err => {
-        t.truthy(err);
-        t.true(err.code === 'ENOENT');
-
-        instance.destroy();
-
-        t.end();
-    });
-});
-
-test('should allow request even before unleash is initialized', t => {
-    const url = mockNetwork();
-    const instance = new Unleash({
-        appName: 'foo',
-        disableMetrics: true,
-        url,
-        backupPath: getRandomBackupPath(),
-    }).on('error', err => {
-        throw err;
-    });
+  instance.on('ready', () => {
     t.true(instance.isEnabled('unknown') === false);
     instance.destroy();
-});
+    resolve();
+  });
+}));
 
-test('should consider known feature-toggle as active', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+test('should return fallback value until online', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            t.true(instance.isEnabled('feature') === true);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  let warnCounter = 0;
+  instance.on('warn', () => {
+    warnCounter++;
+  });
 
-test('should consider unknown feature-toggle as disabled', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+  t.true(instance.isEnabled('feature') === false);
+  t.true(warnCounter === 1);
+  t.true(instance.isEnabled('feature', {}, false) === false);
+  t.true(instance.isEnabled('feature', {}, true) === true);
+  t.true(warnCounter === 3);
 
-        instance.on('ready', () => {
-            t.true(instance.isEnabled('unknown') === false);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    t.true(instance.isEnabled('feature') === true);
+    t.true(instance.isEnabled('feature', {}, false) === true);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('should return fallback value until online', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+test('should call fallback function for unknown feature-toggle', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    environment: 'test',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-        let warnCounter = 0;
-        instance.on('warn', () => {
-            warnCounter++;
-        });
+  instance.on('ready', () => {
+    const fallbackFunc = sinon.spy(() => false);
+    const name = 'unknown';
+    const result = instance.isEnabled(name, { userId: '123' }, fallbackFunc);
+    t.true(result === false);
+    t.true(fallbackFunc.called);
+    t.true(
+      fallbackFunc.firstCall.calledWith(name, {
+        appName: 'foo',
+        environment: 'test',
+        userId: '123',
+      }),
+    );
+    instance.destroy();
+    resolve();
+  });
+}));
 
-        t.true(instance.isEnabled('feature') === false);
-        t.true(warnCounter === 1);
-        t.true(instance.isEnabled('feature', {}, false) === false);
-        t.true(instance.isEnabled('feature', {}, true) === true);
-        t.true(warnCounter === 3);
+test('should not throw when os.userInfo throws', (t) => {
+  t.plan(0);
 
-        instance.on('ready', () => {
-            t.true(instance.isEnabled('feature') === true);
-            t.true(instance.isEnabled('feature', {}, false) === true);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  return new Promise((resolve, reject) => {
+    // eslint-disable-next-line global-require
+    require('os').userInfo = () => {
+      throw new Error('Test exception');
+    };
+    const url = mockNetwork();
+    const instance = new Unleash({
+      appName: 'foo',
+      disableMetrics: true,
+      url,
+      backupPath: getRandomBackupPath(),
+    }).on('error', reject);
 
-test('should call fallback function for unknown feature-toggle', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            environment: 'test',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
-
-        instance.on('ready', () => {
-            const fallbackFunc = sinon.spy(() => false);
-            const name = 'unknown';
-            const result = instance.isEnabled(name, { userId: '123' }, fallbackFunc);
-            t.true(result === false);
-            t.true(fallbackFunc.called);
-            t.true(
-                fallbackFunc.firstCall.calledWith(name, {
-                    appName: 'foo',
-                    environment: 'test',
-                    userId: '123',
-                })
-            );
-            instance.destroy();
-            resolve();
-        });
-    }));
-
-test('should not throw when os.userInfo throws', t => {
-    t.plan(0);
-
-    return new Promise((resolve, reject) => {
-        require('os').userInfo = () => {
-            throw new Error('Test exception');
-        };
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
-
-        instance.on('ready', () => {
-            resolve();
-        });
+    instance.on('ready', () => {
+      resolve();
     });
+  });
 });
 
-test('should return known feature-toggle definition', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+test('should return known feature-toggle definition', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            const toggle = instance.getFeatureToggleDefinition('feature');
-            t.truthy(toggle);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    const toggle = instance.getFeatureToggleDefinition('feature');
+    t.truthy(toggle);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('should return feature-toggles', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+test('should return feature-toggles', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            const toggles = instance.getFeatureToggleDefinitions();
-            t.deepEqual(toggles, defaultToggles);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    const toggles = instance.getFeatureToggleDefinitions();
+    t.deepEqual(toggles, defaultToggles);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('returns undefined for unknown feature-toggle definition', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-        }).on('error', reject);
+test('returns undefined for unknown feature-toggle definition', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            const toggle = instance.getFeatureToggleDefinition('unknown');
-            t.falsy(toggle);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    const toggle = instance.getFeatureToggleDefinition('unknown');
+    t.falsy(toggle);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('should use the injected repository', t =>
-    new Promise((resolve, reject) => {
-        const repo = new FakeRepo();
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-            repository: repo,
-        }).on('error', reject);
-        instance.on('ready', () => {
-            t.false(instance.isEnabled('fake-feature'));
-            instance.destroy();
-            resolve();
-        });
-        repo.emit('ready');
-    }));
+test('should use the injected repository', (t) => new Promise((resolve, reject) => {
+  const repo = new FakeRepo();
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+    repository: repo,
+  }).on('error', reject);
+  instance.on('ready', () => {
+    t.false(instance.isEnabled('fake-feature'));
+    instance.destroy();
+    resolve();
+  });
+  repo.emit('ready');
+}));
 
-test('should add static context fields', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-            environment: 'prod',
-            strategies: [new EnvironmentStrategy()],
-        }).on('error', reject);
+test('should add static context fields', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+    environment: 'prod',
+    strategies: [new EnvironmentStrategy()],
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            t.true(instance.isEnabled('f-context') === true);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    t.true(instance.isEnabled('f-context') === true);
+    instance.destroy();
+    resolve();
+  });
+}));
 
-test('should local context should take precendence over static context fields', t =>
-    new Promise((resolve, reject) => {
-        const url = mockNetwork();
-        const instance = new Unleash({
-            appName: 'foo',
-            disableMetrics: true,
-            url,
-            backupPath: getRandomBackupPath(),
-            environment: 'prod',
-            strategies: [new EnvironmentStrategy()],
-        }).on('error', reject);
+test('should local context should take precedence over static context fields', (t) => new Promise((resolve, reject) => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    url,
+    backupPath: getRandomBackupPath(),
+    environment: 'prod',
+    strategies: [new EnvironmentStrategy()],
+  }).on('error', reject);
 
-        instance.on('ready', () => {
-            t.true(instance.isEnabled('f-context', { environment: 'dev' }) === false);
-            instance.destroy();
-            resolve();
-        });
-    }));
+  instance.on('ready', () => {
+    t.true(instance.isEnabled('f-context', { environment: 'dev' }) === false);
+    instance.destroy();
+    resolve();
+  });
+}));

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -256,33 +256,34 @@ test('should return fallback value until online', (t) => new Promise((resolve, r
   });
 }));
 
-test('should call fallback function for unknown feature-toggle', (t) => new Promise((resolve, reject) => {
-  const url = mockNetwork();
-  const instance = new Unleash({
-    appName: 'foo',
-    environment: 'test',
-    disableMetrics: true,
-    url,
-    backupPath: getRandomBackupPath(),
-  }).on('error', reject);
+test('should call fallback function for unknown feature-toggle',
+  (t) => new Promise((resolve, reject) => {
+    const url = mockNetwork();
+    const instance = new Unleash({
+      appName: 'foo',
+      environment: 'test',
+      disableMetrics: true,
+      url,
+      backupPath: getRandomBackupPath(),
+    }).on('error', reject);
 
-  instance.on('ready', () => {
-    const fallbackFunc = sinon.spy(() => false);
-    const name = 'unknown';
-    const result = instance.isEnabled(name, { userId: '123' }, fallbackFunc);
-    t.true(result === false);
-    t.true(fallbackFunc.called);
-    t.true(
-      fallbackFunc.firstCall.calledWith(name, {
-        appName: 'foo',
-        environment: 'test',
-        userId: '123',
-      }),
-    );
-    instance.destroy();
-    resolve();
-  });
-}));
+    instance.on('ready', () => {
+      const fallbackFunc = sinon.spy(() => false);
+      const name = 'unknown';
+      const result = instance.isEnabled(name, { userId: '123' }, fallbackFunc);
+      t.true(result === false);
+      t.true(fallbackFunc.called);
+      t.true(
+        fallbackFunc.firstCall.calledWith(name, {
+          appName: 'foo',
+          environment: 'test',
+          userId: '123',
+        }),
+      );
+      instance.destroy();
+      resolve();
+    });
+  }));
 
 test('should not throw when os.userInfo throws', (t) => {
   t.plan(0);
@@ -340,22 +341,23 @@ test('should return feature-toggles', (t) => new Promise((resolve, reject) => {
   });
 }));
 
-test('returns undefined for unknown feature-toggle definition', (t) => new Promise((resolve, reject) => {
-  const url = mockNetwork();
-  const instance = new Unleash({
-    appName: 'foo',
-    disableMetrics: true,
-    url,
-    backupPath: getRandomBackupPath(),
-  }).on('error', reject);
+test('returns undefined for unknown feature-toggle definition',
+  (t) => new Promise((resolve, reject) => {
+    const url = mockNetwork();
+    const instance = new Unleash({
+      appName: 'foo',
+      disableMetrics: true,
+      url,
+      backupPath: getRandomBackupPath(),
+    }).on('error', reject);
 
-  instance.on('ready', () => {
-    const toggle = instance.getFeatureToggleDefinition('unknown');
-    t.falsy(toggle);
-    instance.destroy();
-    resolve();
-  });
-}));
+    instance.on('ready', () => {
+      const toggle = instance.getFeatureToggleDefinition('unknown');
+      t.falsy(toggle);
+      instance.destroy();
+      resolve();
+    });
+  }));
 
 test('should use the injected repository', (t) => new Promise((resolve, reject) => {
   const repo = new FakeRepo();
@@ -393,20 +395,21 @@ test('should add static context fields', (t) => new Promise((resolve, reject) =>
   });
 }));
 
-test('should local context should take precedence over static context fields', (t) => new Promise((resolve, reject) => {
-  const url = mockNetwork();
-  const instance = new Unleash({
-    appName: 'foo',
-    disableMetrics: true,
-    url,
-    backupPath: getRandomBackupPath(),
-    environment: 'prod',
-    strategies: [new EnvironmentStrategy()],
-  }).on('error', reject);
+test('should local context should take precedence over static context fields',
+  (t) => new Promise((resolve, reject) => {
+    const url = mockNetwork();
+    const instance = new Unleash({
+      appName: 'foo',
+      disableMetrics: true,
+      url,
+      backupPath: getRandomBackupPath(),
+      environment: 'prod',
+      strategies: [new EnvironmentStrategy()],
+    }).on('error', reject);
 
-  instance.on('ready', () => {
-    t.true(instance.isEnabled('f-context', { environment: 'dev' }) === false);
-    instance.destroy();
-    resolve();
-  });
-}));
+    instance.on('ready', () => {
+      t.true(instance.isEnabled('f-context', { environment: 'dev' }) === false);
+      instance.destroy();
+      resolve();
+    });
+  }));

--- a/test/variants.test.js
+++ b/test/variants.test.js
@@ -2,133 +2,133 @@ import test from 'ava';
 import { selectVariant } from '../lib/variant';
 
 function genVariants(n) {
-    return Array.from(new Array(n)).map((v, i) => ({
-        name: `variant${i + 1}`,
-        payload: {
-            type: 'string',
-            value: '',
-        },
-        weight: 1,
-    }));
+  return Array.from(new Array(n)).map((v, i) => ({
+    name: `variant${i + 1}`,
+    payload: {
+      type: 'string',
+      value: '',
+    },
+    weight: 1,
+  }));
 }
 
 function createFeature(variants) {
-    return {
-        name: 'toggleName',
-        enabled: true,
-        strategies: [],
-        variants: variants || [],
-    };
+  return {
+    name: 'toggleName',
+    enabled: true,
+    strategies: [],
+    variants: variants || [],
+  };
 }
 
-test('selectVariant should return null', t => {
-    const variant = selectVariant(createFeature(), {
-        toggleName: 'toggleName',
-        userId: 'a',
-    });
-    t.true(variant === null);
+test('selectVariant should return null', (t) => {
+  const variant = selectVariant(createFeature(), {
+    toggleName: 'toggleName',
+    userId: 'a',
+  });
+  t.true(variant === null);
 });
 
-test('selectVariant should select on 1 variant', t => {
-    const variant = selectVariant(createFeature(genVariants(1)), {
-        toggleName: 'toggleName',
-        userId: 'a',
-    });
-    t.true(variant.name === 'variant1');
+test('selectVariant should select on 1 variant', (t) => {
+  const variant = selectVariant(createFeature(genVariants(1)), {
+    toggleName: 'toggleName',
+    userId: 'a',
+  });
+  t.true(variant.name === 'variant1');
 });
 
-test('selectVariant should select on 2 variants', t => {
-    const feature = createFeature(genVariants(2));
-    const variant = selectVariant(feature, { toggleName: 'toggleName', userId: 'a' });
-    t.true(variant.name === 'variant1');
-    const variant2 = selectVariant(feature, { toggleName: 'toggleName', userId: '0' });
-    t.true(variant2.name === 'variant2');
+test('selectVariant should select on 2 variants', (t) => {
+  const feature = createFeature(genVariants(2));
+  const variant = selectVariant(feature, { toggleName: 'toggleName', userId: 'a' });
+  t.true(variant.name === 'variant1');
+  const variant2 = selectVariant(feature, { toggleName: 'toggleName', userId: '0' });
+  t.true(variant2.name === 'variant2');
 });
 
-test('selectVariant should select on 3 variants', t => {
-    const feature = createFeature(genVariants(3));
-    const variant = selectVariant(feature, { toggleName: 'toggleName', userId: 'a' });
-    t.true(variant.name === 'variant1');
-    const variant2 = selectVariant(feature, { toggleName: 'toggleName', userId: '0' });
-    t.true(variant2.name === 'variant2');
-    const variant3 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
-    t.true(variant3.name === 'variant3');
+test('selectVariant should select on 3 variants', (t) => {
+  const feature = createFeature(genVariants(3));
+  const variant = selectVariant(feature, { toggleName: 'toggleName', userId: 'a' });
+  t.true(variant.name === 'variant1');
+  const variant2 = selectVariant(feature, { toggleName: 'toggleName', userId: '0' });
+  t.true(variant2.name === 'variant2');
+  const variant3 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
+  t.true(variant3.name === 'variant3');
 });
 
-test('selectVariant should use variant overrides', t => {
-    const variants = genVariants(3);
-    variants[0].overrides = [
-        {
-            contextName: 'userId',
-            values: ['z'],
+test('selectVariant should use variant overrides', (t) => {
+  const variants = genVariants(3);
+  variants[0].overrides = [
+    {
+      contextName: 'userId',
+      values: ['z'],
+    },
+  ];
+
+  const feature = createFeature(variants);
+  const variant1 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
+  t.is(variant1.name, 'variant1');
+});
+
+test('selectVariant should use *first* variant override', (t) => {
+  const variants = genVariants(3);
+  variants[0].overrides = [
+    {
+      contextName: 'userId',
+      values: ['z', 'b'],
+    },
+  ];
+
+  variants[1].overrides = [
+    {
+      contextName: 'userId',
+      values: ['z'],
+    },
+  ];
+
+  const feature = createFeature(variants);
+  const variant1 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
+  t.is(variant1.name, 'variant1');
+});
+
+test('selectVariant should use *first* variant override for userId=132', (t) => {
+  const featureToggle = {
+    name: 'Feature.Variants.override.D',
+    description: 'Variant with overrides',
+    enabled: true,
+    strategies: [],
+    variants: [
+      {
+        name: 'variant1',
+        weight: 33,
+        payload: {
+          type: 'string',
+          value: 'val1',
         },
-    ];
-
-    const feature = createFeature(variants);
-    const variant1 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
-    t.is(variant1.name, 'variant1');
-});
-
-test('selectVariant should use *first* variant override', t => {
-    const variants = genVariants(3);
-    variants[0].overrides = [
-        {
+        overrides: [
+          {
             contextName: 'userId',
-            values: ['z', 'b'],
-        },
-    ];
-
-    variants[1].overrides = [
-        {
-            contextName: 'userId',
-            values: ['z'],
-        },
-    ];
-
-    const feature = createFeature(variants);
-    const variant1 = selectVariant(feature, { toggleName: 'toggleName', userId: 'z' });
-    t.is(variant1.name, 'variant1');
-});
-
-test('selectVariant should use *first* variant override for userId=132', t => {
-    const featureToggle = {
-        name: 'Feature.Variants.override.D',
-        description: 'Variant with overrides',
-        enabled: true,
-        strategies: [],
-        variants: [
-            {
-                name: 'variant1',
-                weight: 33,
-                payload: {
-                    type: 'string',
-                    value: 'val1',
-                },
-                overrides: [
-                    {
-                        contextName: 'userId',
-                        values: ['132', '61'],
-                    },
-                ],
-            },
-            {
-                name: 'variant2',
-                weight: 33,
-                payload: {
-                    type: 'string',
-                    value: 'val2',
-                },
-            },
-            {
-                name: 'variant3',
-                weight: 34,
-                payload: {
-                    type: 'string',
-                    value: 'val3',
-                },
-            },
+            values: ['132', '61'],
+          },
         ],
-    };
-    const variant1 = selectVariant(featureToggle, { userId: '132' });
-    t.is(variant1.name, 'variant1');
+      },
+      {
+        name: 'variant2',
+        weight: 33,
+        payload: {
+          type: 'string',
+          value: 'val2',
+        },
+      },
+      {
+        name: 'variant3',
+        weight: 34,
+        payload: {
+          type: 'string',
+          value: 'val3',
+        },
+      },
+    ],
+  };
+  const variant1 = selectVariant(featureToggle, { userId: '132' });
+  t.is(variant1.name, 'variant1');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,285 +2,121 @@
 # yarn lockfile v1
 
 
-"@ava/babel@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ava/babel/-/babel-1.0.1.tgz#9f005bc0118eee4639827df798c75b77fa5fe35d"
-  integrity sha512-mGKpGeT6J4UjK2sxPjvwWl/GtsF9+eNyn2HHa7OknWWWYuw+rof/UaTAn1CA0z4sTw4Mruik/ihEasMw+JM6aQ==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
   dependencies:
-    "@ava/require-precompiled" "^1.0.0"
-    "@babel/core" "^7.8.4"
-    "@babel/generator" "^7.8.4"
-    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-proposal-optional-chaining" "^7.8.3"
-    "@babel/plugin-transform-modules-commonjs" "^7.8.3"
-    babel-plugin-espower "^3.0.1"
-    concordance "^4.0.0"
-    convert-source-map "^1.7.0"
-    dot-prop "^5.2.0"
-    empower-core "^1.2.0"
-    escape-string-regexp "^2.0.0"
-    find-up "^4.1.0"
-    is-plain-object "^3.0.0"
-    md5-hex "^3.0.1"
-    package-hash "^4.0.0"
-    pkg-conf "^3.1.0"
-    source-map-support "^0.5.16"
-    strip-bom-buf "^2.0.0"
-    write-file-atomic "^3.0.1"
+    "@babel/highlight" "^7.8.3"
 
-"@ava/require-precompiled@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ava/require-precompiled/-/require-precompiled-1.0.0.tgz#6f4a48b75904a753eadff020bbfca81d3bbc0357"
-  integrity sha512-N7w4g+P/SUL8SF+HC4Z4e/ctV6nQ5AERC90K90r4xZQ8WVrJux9albvfyYAzygyU47CSqMWh6yJwFs8DYaeWmg==
-
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
-  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+"@babel/core@^7.7.5":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.3.tgz#30b0ebb4dd1585de6923a0b4d179e0b9f5d82941"
+  integrity sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
   dependencies:
-    "@babel/highlight" "^7.12.13"
-
-"@babel/core@^7.7.5", "@babel/core@^7.8.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.13.tgz#b73a87a3a3e7d142a66248bf6ad88b9ceb093425"
-  integrity sha512-BQKE9kXkPlXHPeqissfxo0lySWJcYdEP0hdtJOH/iJfDdhOCcgtNCjftCJg3qqauB4h+lz2N6ixM++b9DN1Tcw==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.12.13"
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helpers" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.3"
+    "@babel/helpers" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.3"
+    "@babel/types" "^7.8.3"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.12.13", "@babel/generator@^7.8.4":
-  version "7.12.15"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.15.tgz#4617b5d0b25cc572474cc1aafee1edeaf9b5368f"
-  integrity sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==
+"@babel/generator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
+  integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.8.3"
     jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
-  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+"@babel/helper-function-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
+  integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.12.13"
-    "@babel/template" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
-"@babel/helper-get-function-arity@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
-  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.8.3"
 
-"@babel/helper-member-expression-to-functions@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz#c5715695b4f8bab32660dbdcdc2341dec7e3df40"
-  integrity sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
-  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
+"@babel/helpers@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.3.tgz#382fbb0382ce7c4ce905945ab9641d688336ce85"
+  integrity sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
-"@babel/helper-module-transforms@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz#01afb052dcad2044289b7b20beb3fa8bd0265bea"
-  integrity sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==
+"@babel/highlight@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
+  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
   dependencies:
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-replace-supers" "^7.12.13"
-    "@babel/helper-simple-access" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/helper-validator-identifier" "^7.12.11"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
-    lodash "^4.17.19"
-
-"@babel/helper-optimise-call-expression@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
-  integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
-  dependencies:
-    "@babel/types" "^7.12.13"
-
-"@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz#174254d0f2424d8aefb4dd48057511247b0a9eeb"
-  integrity sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==
-
-"@babel/helper-replace-supers@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz#00ec4fb6862546bd3d0aff9aac56074277173121"
-  integrity sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.12.13"
-    "@babel/helper-optimise-call-expression" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
-
-"@babel/helper-simple-access@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz#8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4"
-  integrity sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
-  dependencies:
-    "@babel/types" "^7.12.13"
-
-"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
-  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
-  dependencies:
-    "@babel/types" "^7.12.1"
-
-"@babel/helper-split-export-declaration@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
-  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
-  dependencies:
-    "@babel/types" "^7.12.13"
-
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
-
-"@babel/helpers@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.13.tgz#3c75e993632e4dadc0274eae219c73eb7645ba47"
-  integrity sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==
-  dependencies:
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
-
-"@babel/highlight@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
-  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
+    esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.12.13", "@babel/parser@^7.7.5":
-  version "7.12.15"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.15.tgz#2b20de7f0b4b332d9b119dd9c33409c538b8aacf"
-  integrity sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==
-
-"@babel/plugin-proposal-dynamic-import@^7.8.3":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz#43eb5c2a3487ecd98c5c8ea8b5fdb69a2749b2dc"
-  integrity sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.13.tgz#24867307285cee4e1031170efd8a7ac807deefde"
-  integrity sha512-Qoxpy+OxhDBI5kRqliJFAl4uWXk3Bn24WeFstPH0iLymFehSAUR8MHpqU7njyXv/qbo7oN6yTy5bfCmXdKpo1Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
-
-"@babel/plugin-proposal-optional-chaining@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.13.tgz#63a7d805bc8ce626f3234ee5421a2a7fb23f66d9"
-  integrity sha512-0ZwjGfTcnZqyV3y9DSD1Yk3ebp+sIUpT2YDqP8hovzaNZnQq2Kd7PEqa6iOIUDBXBt7Jl3P7YAcEIL5Pz8u09Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-
-"@babel/plugin-syntax-dynamic-import@^7.8.0":
+"@babel/parser@^7.7.5", "@babel/parser@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
-  integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
+  integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
-  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
+  integrity sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
-  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
+  integrity sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
-
-"@babel/plugin-transform-modules-commonjs@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.13.tgz#5043b870a784a8421fa1fd9136a24f294da13e50"
-  integrity sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==
-  dependencies:
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-simple-access" "^7.12.13"
-    babel-plugin-dynamic-import-node "^2.3.3"
-
-"@babel/runtime@^7.6.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
-  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/template@^7.12.13", "@babel/template@^7.7.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
-  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/types" "^7.12.13"
-
-"@babel/traverse@^7.12.13", "@babel/traverse@^7.7.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.13.tgz#689f0e4b4c08587ad26622832632735fb8c4e0c0"
-  integrity sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.12.13"
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.3"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.19"
+    lodash "^4.17.13"
 
-"@babel/types@^7.12.1", "@babel/types@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
-  integrity sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
+"@babel/types@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
+  integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@concordance/react@^2.0.0":
@@ -290,14 +126,29 @@
   dependencies:
     arrify "^1.0.1"
 
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.20"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
-  integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
+  integrity sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==
   dependencies:
     camelcase "^5.3.1"
     find-up "^4.1.0"
-    get-package-type "^0.1.0"
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
@@ -306,40 +157,40 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@nodelib/fs.scandir@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
-  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
   dependencies:
-    "@nodelib/fs.stat" "2.0.4"
+    "@nodelib/fs.stat" "2.0.3"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
-  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
-  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.4"
+    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@samverschueren/stream-to-observable@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
-  integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
-  dependencies:
-    any-observable "^0.3.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
+  integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.8.1":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
   integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
@@ -347,38 +198,20 @@
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz#b64b0faadfdd01a6dcf0c4dcdb78438d86fa7dbf"
+  integrity sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sinonjs/formatio@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-4.0.1.tgz#50ac1da0c3eaea117ca258b06f4f88a471668bdb"
-  integrity sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^4.2.0"
-
-"@sinonjs/formatio@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
-  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^5.0.2"
-
-"@sinonjs/samsam@^4.2.0":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-4.2.2.tgz#0f6cb40e467865306d8a20a97543a94005204e23"
-  integrity sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==
-  dependencies:
-    "@sinonjs/commons" "^1.6.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
-
-"@sinonjs/samsam@^5.0.1", "@sinonjs/samsam@^5.0.2":
+"@sinonjs/samsam@^5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
   integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
@@ -411,10 +244,27 @@
   dependencies:
     "@types/node" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/murmurhash3js@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/murmurhash3js/-/murmurhash3js-3.0.2.tgz#eeaf46ed69b0e473f0c310a383c9362c299981f7"
   integrity sha512-xx8QZPFSzd5520I/EVZCNYUEzTPHYkKf+V0CBDPMA/X0vRRQRkFiEjTfoM3Yd+oE0jTKR/qZ+vDWF+2PMaVXMg==
+
+"@types/nock@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
+  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
+  dependencies:
+    nock "*"
 
 "@types/node-fetch@^2.5.8":
   version "2.5.8"
@@ -424,7 +274,12 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.0.1":
+"@types/node@*":
+  version "13.1.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.8.tgz#1d590429fe8187a02707720ecf38a6fe46ce294b"
+  integrity sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
+
+"@types/node@^14.0.1":
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.1.tgz#5d93e0a099cd0acd5ef3d5bde3c086e1f49ff68c"
   integrity sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
@@ -439,25 +294,96 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@typescript-eslint/eslint-plugin@^4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz#47a15803cfab89580b96933d348c2721f3d2f6fe"
+  integrity sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.14.2"
+    "@typescript-eslint/scope-manager" "4.14.2"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz#9df35049d1d36b6cbaba534d703648b9e1f05cbb"
+  integrity sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.14.2"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/typescript-estree" "4.14.2"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^4.4.1":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.2.tgz#31e216e4baab678a56e539f9db9862e2542c98d0"
+  integrity sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.14.2"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/typescript-estree" "4.14.2"
+    debug "^4.1.1"
+
+"@typescript-eslint/scope-manager@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz#64cbc9ca64b60069aae0c060b2bf81163243b266"
+  integrity sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
+
+"@typescript-eslint/types@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.2.tgz#d96da62be22dc9dc6a06647f3633815350fb3174"
+  integrity sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==
+
+"@typescript-eslint/typescript-estree@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz#9c5ebd8cae4d7b014f890acd81e8e17f309c9df9"
+  integrity sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz#997cbe2cb0690e1f384a833f64794e98727c70c6"
+  integrity sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    eslint-visitor-keys "^2.0.0"
+
 "@unleash/client-specification@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@unleash/client-specification/-/client-specification-3.3.1.tgz#4f0527c7bf1d6f77d7dbb909f698340f8b117049"
   integrity sha512-B+NlU9LSGPLKJ7LpKW//2XcFhTZLruGNoiy/o2Zd93RRLpf1Yy9Bpyw8hsZw8tZrdRweWOXyFbttXroqk1j1ww==
 
-acorn-jsx@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
-  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+acorn-jsx@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-walk@^8.0.0:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3"
   integrity sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==
 
-acorn@^6.0.7:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.0.4:
   version "8.0.5"
@@ -472,7 +398,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.10.0:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -482,6 +408,26 @@ ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^6.12.3, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.0.4.tgz#827e5f5ae32f5e5c1637db61f253a112229b5e2f"
+  integrity sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -489,20 +435,17 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
-ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+ansi-escapes@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
+  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  dependencies:
+    type-fest "^0.11.0"
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -514,12 +457,7 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -538,11 +476,6 @@ ansi-styles@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.1.0.tgz#a436bcc51d81f4fab5080b2ba94242e377c41573"
   integrity sha512-osxifZo3ar56+e8tdYreU6p8FZGciBHo5O0JoDAxMUqZuyNUb+yHEwYtJZ+Z32R459jEgtwVf1u8D7qYwU0l6w==
-
-any-observable@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
-  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 anymatch@~3.1.1:
   version "3.1.1"
@@ -576,10 +509,30 @@ array-find-index@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
+array-includes@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.2.tgz#a8db03e0b88c8c6aeddc49cb132f9bcab4ebf9c8"
+  integrity sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    get-intrinsic "^1.0.1"
+    is-string "^1.0.5"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
 
 arrgv@^1.0.2:
   version "1.0.2"
@@ -608,10 +561,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -695,26 +648,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-babel-plugin-dynamic-import-node@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
-babel-plugin-espower@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz#180db17126f88e754105b8b5216d21e520a6bd4e"
-  integrity sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==
-  dependencies:
-    "@babel/generator" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    call-matcher "^1.0.0"
-    core-js "^2.0.0"
-    espower-location-detector "^1.0.0"
-    espurify "^1.6.0"
-    estraverse "^4.1.1"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -738,9 +671,9 @@ binary-extensions@^2.0.0:
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
 bl@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.4.tgz#f4fda39f81a811d0df6368c1ed91dae499d1c900"
+  integrity sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"
@@ -824,21 +757,6 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-call-matcher@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/call-matcher/-/call-matcher-1.1.0.tgz#23b2c1bc7a8394c8be28609d77ddbd5786680432"
-  integrity sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==
-  dependencies:
-    core-js "^2.0.0"
-    deep-equal "^1.0.0"
-    espurify "^1.6.0"
-    estraverse "^4.0.0"
-
-call-signature@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
-  integrity sha1-qEq8glpV70yysCi9dOIFpluaSZY=
-
 callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -859,18 +777,19 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.0.0, chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
   dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -878,14 +797,6 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
@@ -895,10 +806,10 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@^3.4.3:
   version "3.5.1"
@@ -945,13 +856,6 @@ cli-boxes@^2.2.1:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
-cli-cursor@^2.0.0, cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
-  dependencies:
-    restore-cursor "^2.0.0"
-
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -964,14 +868,6 @@ cli-spinners@^2.5.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
   integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
 
-cli-truncate@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
-  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
-  dependencies:
-    slice-ansi "0.0.4"
-    string-width "^1.0.1"
-
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -979,11 +875,6 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
-
-cli-width@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -1022,11 +913,6 @@ code-excerpt@^3.0.0:
   dependencies:
     convert-to-spaces "^1.0.1"
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
-
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1051,17 +937,24 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+commander@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -1073,32 +966,15 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-compare-versions@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.5.1.tgz#26e1f5cf0d48a77eced5046b9f67b6b61075a393"
-  integrity sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg==
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-concordance@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/concordance/-/concordance-4.0.0.tgz#5932fdee397d129bdbc3a1885fbe69839b1b7e15"
-  integrity sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==
-  dependencies:
-    date-time "^2.1.0"
-    esutils "^2.0.2"
-    fast-diff "^1.1.2"
-    js-string-escape "^1.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.flattendeep "^4.4.0"
-    lodash.islength "^4.0.1"
-    lodash.merge "^4.6.1"
-    md5-hex "^2.0.0"
-    semver "^5.5.1"
-    well-known-symbols "^2.0.0"
 
 concordance@^5.0.1:
   version "5.0.1"
@@ -1126,6 +1002,16 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
+confusing-browser-globals@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
+  integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -1138,61 +1024,62 @@ convert-to-spaces@^1.0.1:
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
   integrity sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=
 
-core-js@^2.0.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
-  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
   dependencies:
     "@types/parse-json" "^4.0.0"
-    import-fresh "^3.1.0"
+    import-fresh "^3.2.1"
     parse-json "^5.0.0"
     path-type "^4.0.0"
-    yaml "^1.7.2"
+    yaml "^1.10.0"
 
-coveralls@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.3.tgz#83b1c64aea1c6afa69beaf50b55ac1bc4d13e2b8"
-  integrity sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==
+coveralls@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.0.tgz#13c754d5e7a2dd8b44fe5269e21ca394fb4d615b"
+  integrity sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==
   dependencies:
-    growl "~> 1.10.0"
-    js-yaml "^3.11.0"
-    lcov-parse "^0.0.10"
+    js-yaml "^3.13.1"
+    lcov-parse "^1.0.0"
     log-driver "^1.2.7"
-    minimist "^1.2.0"
-    request "^2.86.0"
+    minimist "^1.2.5"
+    request "^2.88.2"
 
-cross-env@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.0.tgz#5a3b2ddce51ec713ea58f2fb79ce22e65b4f5479"
-  integrity sha512-rV6M9ldNgmwP7bx5u6rZsTbYidzwvrwIYZnT08hSGLcQCcggofgFW+sNe7IhA1SRauPS0QuLbbX+wdNtpqE5CQ==
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-spawn@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+cross-spawn@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.0.tgz#21ef9470443262f33dba80b2705a91db959b2e03"
+  integrity sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==
   dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
+    path-key "^3.1.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.1:
+cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -1217,18 +1104,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-date-time@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
-  integrity sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==
-  dependencies:
-    time-zone "^1.0.0"
-
 date-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-3.1.0.tgz#0d1e934d170579f481ed8df1e2b8ff70ee845e1e"
@@ -1236,7 +1111,21 @@ date-time@^3.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.2.0, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -1260,24 +1149,19 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
-  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.1"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object-keys "^1.1.1"
-    regexp.prototype.flags "^1.2.0"
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -1339,6 +1223,14 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1366,11 +1258,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
-  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
-
 emittery@^0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
@@ -1386,14 +1273,6 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-empower-core@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/empower-core/-/empower-core-1.2.0.tgz#ce3fb2484d5187fa29c23fba8344b0b2fdf5601c"
-  integrity sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==
-  dependencies:
-    call-signature "0.0.2"
-    core-js "^2.0.0"
-
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -1401,17 +1280,53 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enquirer@^2.3.5, enquirer@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 equal-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/equal-length/-/equal-length-1.0.1.tgz#21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c"
   integrity sha1-IcoRLUirJLTh5//A5TOdMf38J0w=
 
-error-ex@^1.3.1:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.18.0-next.1:
+  version "1.18.0-next.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
+  integrity sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.1"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.3"
+    string.prototype.trimstart "^1.0.3"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es6-error@^4.0.1:
   version "4.1.1"
@@ -1428,7 +1343,7 @@ escape-goat@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1443,163 +1358,200 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-finn-prettier@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-finn-prettier/-/eslint-config-finn-prettier-3.0.2.tgz#4f21015d9a0d561feda55c2015935910a24f4808"
-  integrity sha512-vfr8fiVOWzYAdSNdOlPseijuAU5Cyv5hfQWJ2m3buyRrcDjv5+rvrBlkkmOYiBdh5uXf6xEgidY7W4eVsg6NLA==
+eslint-config-airbnb-base@^14.2.0, eslint-config-airbnb-base@^14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
+  integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
   dependencies:
-    eslint-config-prettier "^3.0.1"
-    eslint-plugin-prettier "^2.6.2"
+    confusing-browser-globals "^1.0.10"
+    object.assign "^4.1.2"
+    object.entries "^1.1.2"
 
-eslint-config-finn@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-finn/-/eslint-config-finn-3.0.1.tgz#edec7dce85ff0f385dc57171e4ce7b92cd3f3a94"
-  integrity sha512-BnLRL5GQGpb3zR2clZdcuOfRVH6P/rf74C1wBLI0kpsbogNdy9f/xB6JYdMhNMHip0F9RTP5CRDoW8LgAk8QoQ==
+eslint-config-airbnb-typescript@^12.3.1:
+  version "12.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.3.1.tgz#83ab40d76402c208eb08516260d1d6fac8f8acbc"
+  integrity sha512-ql/Pe6/hppYuRp4m3iPaHJqkBB7dgeEmGPQ6X0UNmrQOfTF+dXw29/ZjU2kQ6RDoLxaxOA+Xqv07Vbef6oVTWw==
   dependencies:
-    eslint-config-schibsted "^4.0.0"
+    "@typescript-eslint/parser" "^4.4.1"
+    eslint-config-airbnb "^18.2.0"
+    eslint-config-airbnb-base "^14.2.0"
 
-eslint-config-prettier@^3.0.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz#41afc8d3b852e757f06274ed6c44ca16f939a57d"
-  integrity sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==
+eslint-config-airbnb@^18.2.0:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
+  integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
   dependencies:
-    get-stdin "^6.0.0"
+    eslint-config-airbnb-base "^14.2.1"
+    object.assign "^4.1.2"
+    object.entries "^1.1.2"
 
-eslint-config-schibsted@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-schibsted/-/eslint-config-schibsted-4.0.0.tgz#7c0dacdc18d56a2dac006923917ef40df29438ed"
-  integrity sha1-fA2s3BjVai2sAGkjkX70DfKUOO0=
+eslint-config-prettier@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
+  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
 
-eslint-plugin-prettier@^2.6.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
-  integrity sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==
+eslint-import-resolver-node@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^21.0.0"
+    debug "^2.6.9"
+    resolve "^1.13.1"
 
-eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+eslint-module-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
+  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
   dependencies:
-    esrecurse "^4.1.0"
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.4"
+    eslint-module-utils "^2.6.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.1"
+    read-pkg-up "^2.0.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
+eslint-plugin-prettier@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
-  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
-    eslint-visitor-keys "^1.0.0"
+    eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.1.0.tgz#06438a4a278b1d84fb107d24eaaa35471986e646"
-  integrity sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.19.0:
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.19.0.tgz#6719621b196b5fad72e43387981314e5d0dc3f41"
+  integrity sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
+    "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^6.0.0"
-    esquery "^1.0.1"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.2.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    file-entry-cache "^6.0.0"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^11.7.0"
+    globals "^12.1.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.4.1"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.14"
+    levn "^0.4.1"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
-    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.2"
+    optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^6.1.2"
-    strip-ansi "^5.2.0"
-    strip-json-comments "^3.0.1"
-    table "^5.2.3"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espower-location-detector@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/espower-location-detector/-/espower-location-detector-1.0.0.tgz#a17b7ecc59d30e179e2bef73fb4137704cb331b5"
-  integrity sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=
-  dependencies:
-    is-url "^1.2.1"
-    path-is-absolute "^1.0.0"
-    source-map "^0.5.0"
-    xtend "^4.0.0"
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
-espree@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
-  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-espurify@^1.6.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/espurify/-/espurify-1.8.1.tgz#5746c6c1ab42d302de10bd1d5bf7f0e8c0515056"
-  integrity sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==
+esquery@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
-    core-js "^2.0.0"
+    estraverse "^5.1.0"
 
-esquery@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
-  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.0.0"
+    estraverse "^5.2.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
-  dependencies:
-    estraverse "^4.1.0"
-
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2, esutils@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-execa@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
-  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+execa@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"
@@ -1608,7 +1560,6 @@ execa@^3.4.0:
     merge-stream "^2.0.0"
     npm-run-path "^4.0.0"
     onetime "^5.1.0"
-    p-finally "^2.0.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
@@ -1616,15 +1567,6 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-external-editor@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
-  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
 
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
@@ -1636,7 +1578,12 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-diff@^1.1.1, fast-diff@^1.1.2, fast-diff@^1.2.0:
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2, fast-diff@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
@@ -1658,7 +1605,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -1670,21 +1617,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.0"
 
-figures@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
-
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
 figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -1692,12 +1624,12 @@ figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+file-entry-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.0.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
+  integrity sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
   dependencies:
-    flat-cache "^2.0.1"
+    flat-cache "^3.0.4"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1715,6 +1647,13 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.0"
     pkg-dir "^4.1.0"
 
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -1730,26 +1669,33 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-versions@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
-  integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
-    semver-regex "^2.0.0"
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+find-versions@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-4.0.0.tgz#3c57e573bf97769b8cb8df16934b627915da4965"
+  integrity sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
   dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
+    semver-regex "^3.1.2"
 
-flatted@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
-  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 foreground-child@^2.0.0:
   version "2.0.0"
@@ -1817,7 +1763,12 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2:
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -1835,11 +1786,6 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -1888,10 +1834,17 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
 
 globby@^11.0.1:
   version "11.0.2"
@@ -1922,35 +1875,28 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
-  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-"growl@~> 1.10.0":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+graceful-fs@^4.2.4:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.5.tgz#bc18864a6c9fc7b303f2e2abdb9155ad178fbe29"
+  integrity sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==
 
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^6.5.5"
+    ajv "^6.12.3"
     har-schema "^2.0.0"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2016,28 +1962,21 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.1.tgz#b09f1bd9129e6c323cc515dc17081d0615e2d7c1"
-  integrity sha512-Qa0lRreeIf4Tl92sSs42ER6qc3hzoyQPPorzOrFWfPEVbdi6LuvJEqWKPk905fOWIR76iBpp7ECZNIwk+a8xuQ==
+husky@^4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
+  integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
   dependencies:
-    chalk "^3.0.0"
+    chalk "^4.0.0"
     ci-info "^2.0.0"
-    compare-versions "^3.5.1"
-    cosmiconfig "^6.0.0"
-    find-versions "^3.2.0"
+    compare-versions "^3.6.0"
+    cosmiconfig "^7.0.0"
+    find-versions "^4.0.0"
     opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
+    pkg-dir "^5.0.0"
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
-
-iconv-lite@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -2059,10 +1998,18 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-import-fresh@^3.0.0, import-fresh@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -2084,11 +2031,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -2118,25 +2060,6 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
-inquirer@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
-  integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
-  dependencies:
-    ansi-escapes "^3.2.0"
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^2.0.0"
-    lodash "^4.17.12"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.1.0"
-    through "^2.3.6"
-
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -2146,13 +2069,6 @@ irregular-plurals@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.2.0.tgz#b19c490a0723798db51b235d7e39add44dab0822"
   integrity sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==
-
-is-arguments@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
-  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
-  dependencies:
-    call-bind "^1.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2166,12 +2082,24 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-callable@^1.1.4, is-callable@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
 
 is-date-object@^1.0.1:
   version "1.0.2"
@@ -2188,13 +2116,6 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -2205,7 +2126,14 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2224,6 +2152,11 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
 is-npm@^5.0.0:
   version "5.0.0"
@@ -2245,13 +2178,6 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
-is-observable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
-  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
-  dependencies:
-    symbol-observable "^1.1.0"
-
 is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
@@ -2262,27 +2188,17 @@ is-path-inside@^3.0.2:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
-is-plain-object@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
-  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
-
 is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-promise@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
-is-regex@^1.0.4:
+is-regex@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
   integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
@@ -2295,30 +2211,27 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
 is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-is-url@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
-  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
-
-is-utf8@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -2334,6 +2247,11 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2409,11 +2327,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-docblock@^21.0.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
-  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -2424,7 +2337,15 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.11.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -2457,6 +2378,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -2472,12 +2398,19 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
-    minimist "^1.2.5"
+    minimist "^1.2.0"
+
+json5@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  dependencies:
+    minimist "^1.2.0"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2508,86 +2441,69 @@ latest-version@^5.1.0:
   dependencies:
     package-json "^6.3.0"
 
-lcov-parse@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
+lcov-parse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-1.0.0.tgz#eb0d46b54111ebc561acb4c408ef9363bdc8f7e0"
+  integrity sha1-6w1GtUER68VhrLTECO+TY73I9+A=
 
-levn@^0.3.0, levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.3:
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.7.tgz#d205f92d9359419a23bc6aa3b6f8546b1998da64"
-  integrity sha512-Byj0F4l7GYUpYYHEqyFH69NiI6ICTg0CeCKbhRorL+ickbzILKUlZLiyCkljZV02wnoh7yH7PmFyYm9PRNwk9g==
+lint-staged@^10.5.4:
+  version "10.5.4"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.4.tgz#cd153b5f0987d2371fc1d2847a409a2fe705b665"
+  integrity sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==
   dependencies:
-    chalk "^3.0.0"
-    commander "^4.0.1"
-    cosmiconfig "^6.0.0"
-    debug "^4.1.1"
+    chalk "^4.1.0"
+    cli-truncate "^2.1.0"
+    commander "^6.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.2.0"
     dedent "^0.7.0"
-    execa "^3.4.0"
-    listr "^0.14.3"
-    log-symbols "^3.0.0"
+    enquirer "^2.3.6"
+    execa "^4.1.0"
+    listr2 "^3.2.2"
+    log-symbols "^4.0.0"
     micromatch "^4.0.2"
     normalize-path "^3.0.0"
     please-upgrade-node "^3.2.0"
     string-argv "0.3.1"
     stringify-object "^3.3.0"
 
-listr-silent-renderer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
-  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
-
-listr-update-renderer@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
-  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+listr2@^3.2.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.3.1.tgz#87b57cc0b8541fa794b814c8bcb76f1211cfbf5c"
+  integrity sha512-8Zoxe7s/8nNr4bJ8bdAduHD8uJce+exmMmUWTXlq0WuUdffnH3muisHPHPFtW2vvOfohIsq7FGCaguUxN/h3Iw==
   dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^2.3.0"
-    strip-ansi "^3.0.1"
+    chalk "^4.1.0"
+    cli-truncate "^2.1.0"
+    figures "^3.2.0"
+    indent-string "^4.0.0"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rxjs "^6.6.3"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
 
-listr-verbose-renderer@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
-  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
   dependencies:
-    chalk "^2.4.1"
-    cli-cursor "^2.1.0"
-    date-fns "^1.27.2"
-    figures "^2.0.0"
-
-listr@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
-  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
-  dependencies:
-    "@samverschueren/stream-to-observable" "^0.3.0"
-    is-observable "^1.1.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.5.0"
-    listr-verbose-renderer "^0.5.0"
-    p-map "^2.0.0"
-    rxjs "^6.3.3"
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
 load-json-file@^5.2.0:
   version "5.3.0"
@@ -2599,6 +2515,14 @@ load-json-file@^5.2.0:
     pify "^4.0.1"
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -2615,10 +2539,12 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -2630,22 +2556,17 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.islength@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.islength/-/lodash.islength-4.0.1.tgz#4e9868d452575d750affd358c979543dc20ed577"
-  integrity sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=
-
-lodash.merge@^4.6.1:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.13, lodash@^4.17.15:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -2655,20 +2576,6 @@ log-driver@^1.2.7:
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
   integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
-log-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
-  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
-  dependencies:
-    chalk "^1.0.0"
-
-log-symbols@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
-  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
-  dependencies:
-    chalk "^2.4.2"
-
 log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -2676,14 +2583,15 @@ log-symbols@^4.0.0:
   dependencies:
     chalk "^4.0.0"
 
-log-update@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
-  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
   dependencies:
-    ansi-escapes "^3.0.0"
-    cli-cursor "^2.0.0"
-    wrap-ansi "^3.0.1"
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -2723,24 +2631,12 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
-md5-hex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-2.0.0.tgz#d0588e9f1c74954492ecd24ac0ac6ce997d92e33"
-  integrity sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=
-  dependencies:
-    md5-o-matic "^0.1.1"
-
 md5-hex@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c"
   integrity sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==
   dependencies:
     blueimp-md5 "^2.10.0"
-
-md5-o-matic@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
-  integrity sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=
 
 mem@^8.0.0:
   version "8.0.0"
@@ -2780,11 +2676,6 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "~1.37.0"
 
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2807,24 +2698,39 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@^0.5.1:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+mkdirp@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
-    minimist "^1.2.5"
+    minimist "0.0.8"
 
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-ms@2.1.2:
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2839,32 +2745,33 @@ murmurhash3js@^3.0.1:
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
   integrity sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg=
 
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-nice-try@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-nise@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.1.tgz#16c1b893e8ac4e3958dcab5cc174c07c8ff42cdc"
-  integrity sha512-10PKL272rqg80o2RsWcTT6X9cDYqJ4kXqPTf8yCXPc9hbphZSDmbiG5FqUNeR5nouKCQMM24ld45kgYnBdx2rw==
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
     "@sinonjs/fake-timers" "^6.0.0"
-    "@sinonjs/formatio" "^4.0.1"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
+
+nock@*:
+  version "11.3.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-11.3.5.tgz#f2c7b4b672a04c35342593b6bfd821497881199c"
+  integrity sha512-6WGeZcWc3RExkBcMSYSrUm/5YukDo52m/jhwniQyrnuiCnKRljBwwje9vTwJyEi4J6m2bq0Aj6C1vzuM6iuaeg==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    mkdirp "^0.5.0"
+    propagate "^2.0.0"
 
 nock@^13.0.7:
   version "13.0.7"
@@ -2888,7 +2795,7 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -2914,11 +2821,6 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nyc@^15.1.0:
   version "15.1.0"
@@ -2958,25 +2860,17 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
-object-is@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
-  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
+object-inspect@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0:
+object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -2986,19 +2880,32 @@ object.assign@^4.1.0:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
+object.entries@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6"
+  integrity sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    has "^1.0.3"
+
+object.values@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
+  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    has "^1.0.3"
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
-  dependencies:
-    mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
   version "5.1.0"
@@ -3012,17 +2919,17 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
-optionator@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    wordwrap "~1.0.0"
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 ora@^5.2.0:
   version "5.3.0"
@@ -3037,11 +2944,6 @@ ora@^5.2.0:
     log-symbols "^4.0.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 p-cancelable@^1.0.0:
   version "1.1.0"
@@ -3065,10 +2967,12 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-finally@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
-  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -3076,6 +2980,20 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
   dependencies:
     p-try "^2.0.0"
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -3091,10 +3009,12 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-map@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
-  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map@^3.0.0:
   version "3.0.0"
@@ -3116,6 +3036,11 @@ p-timeout@^3.1.0:
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -3148,6 +3073,13 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+  dependencies:
+    error-ex "^1.2.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -3187,11 +3119,6 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
-
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
@@ -3209,20 +3136,42 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.0.5:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
+picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
 pify@^4.0.1:
   version "4.0.1"
@@ -3237,12 +3186,26 @@ pkg-conf@^3.1.0:
     find-up "^3.0.0"
     load-json-file "^5.2.0"
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -3258,20 +3221,27 @@ plur@^4.0.0:
   dependencies:
     irregular-plurals "^3.2.0"
 
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.17.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-ms@^7.0.1:
   version "7.0.1"
@@ -3297,10 +3267,10 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
-psl@^1.1.24:
-  version "1.1.31"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
-  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+psl@^1.1.28:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -3310,12 +3280,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -3341,6 +3306,23 @@ rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^5.2.0:
   version "5.2.0"
@@ -3368,23 +3350,10 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
-regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
-
-regexp.prototype.flags@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+regexpp@^3.0.0, regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 registry-auth-token@^4.0.0:
   version "4.1.1"
@@ -3407,10 +3376,10 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
-request@^2.86.0:
-  version "2.88.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -3419,7 +3388,7 @@ request@^2.86.0:
     extend "~3.0.2"
     forever-agent "~0.6.1"
     form-data "~2.3.2"
-    har-validator "~5.1.0"
+    har-validator "~5.1.3"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -3429,7 +3398,7 @@ request@^2.86.0:
     performance-now "^2.1.0"
     qs "~6.5.2"
     safe-buffer "^5.1.2"
-    tough-cookie "~2.4.3"
+    tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
@@ -3437,6 +3406,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -3461,6 +3435,21 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.13.1, resolve@^1.17.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
+resolve@^1.3.2:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
@@ -3473,14 +3462,6 @@ responselike@^1.0.2:
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
-
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -3495,50 +3476,48 @@ reusify@^1.0.0:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
-  dependencies:
-    is-promise "^2.1.0"
-
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
-rxjs@^6.3.3, rxjs@^6.4.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
-  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+safe-buffer@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-safe-buffer@~5.1.1:
+safe-buffer@^5.1.2, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -3555,22 +3534,22 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-semver-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
-  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+semver-regex@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
+  integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2, semver@^7.3.4:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -3618,37 +3597,22 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-sinon@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.0.tgz#9f1ed502fa2e287e65220de08f6a44f33e314006"
-  integrity sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==
+sinon@^9.2.4:
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
+  integrity sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
-    "@sinonjs/formatio" "^5.0.0"
-    "@sinonjs/samsam" "^5.0.1"
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/samsam" "^5.3.1"
     diff "^4.0.2"
-    nise "^4.0.1"
+    nise "^4.0.4"
     supports-color "^7.1.0"
 
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
-
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -3659,7 +3623,16 @@ slice-ansi@^3.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.19:
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
+source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -3747,23 +3720,6 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-string-width@^2.1.0, string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -3782,6 +3738,22 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string.prototype.trimend@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -3798,21 +3770,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -3825,13 +3783,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-bom-buf@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz#ff9c223937f8e7154b77e9de9bde094186885c15"
-  integrity sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==
-  dependencies:
-    is-utf8 "^0.2.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -3848,10 +3799,10 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
-  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -3869,11 +3820,6 @@ supertap@^2.0.0:
     serialize-error "^7.0.1"
     strip-ansi "^6.0.0"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -3888,20 +3834,15 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-symbol-observable@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
-
-table@^5.2.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.3.3.tgz#eae560c90437331b74200e011487a33442bd28b4"
-  integrity sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==
+table@^6.0.4:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.7.tgz#e45897ffbcc1bcf9e8a87bf420f2c9e5a7a52a34"
+  integrity sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
   dependencies:
-    ajv "^6.9.1"
-    lodash "^4.17.11"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    ajv "^7.0.2"
+    lodash "^4.17.20"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
 
 temp-dir@^2.0.0:
   version "2.0.0"
@@ -3922,7 +3863,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-through@^2.3.6:
+through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -3931,13 +3872,6 @@ time-zone@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -3956,23 +3890,45 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
-  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
-    psl "^1.1.24"
-    punycode "^1.4.1"
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 trim-off-newlines@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.17.1:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.20.0.tgz#ea03ea45462e146b53d70ce0893de453ff24f698"
+  integrity sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3986,17 +3942,22 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
-    prelude-ls "~1.1.2"
+    prelude-ls "^1.2.1"
 
-type-detect@4.0.8, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
 type-fest@^0.13.1:
   version "0.13.1"
@@ -4018,7 +3979,7 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-fest@^0.8.0:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -4030,10 +3991,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
-  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -4081,7 +4042,12 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -4151,18 +4117,10 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
-
-wrap-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
-  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
+word-wrap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -4187,7 +4145,17 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^3.0.0, write-file-atomic@^3.0.1, write-file-atomic@^3.0.3:
+write-file-atomic@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
+  integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
+write-file-atomic@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
@@ -4197,22 +4165,10 @@ write-file-atomic@^3.0.0, write-file-atomic@^3.0.1, write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
-
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
-
-xtend@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.0"
@@ -4229,17 +4185,15 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
-  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
-  dependencies:
-    "@babel/runtime" "^7.6.3"
+yaml@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
+  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@^18.1.2:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -4250,9 +4204,9 @@ yargs-parser@^20.2.2:
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs@^15.0.2:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
-  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
   dependencies:
     cliui "^6.0.0"
     decamelize "^1.2.0"
@@ -4264,7 +4218,7 @@ yargs@^15.0.2:
     string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.2"
+    yargs-parser "^16.1.0"
 
 yargs@^16.2.0:
   version "16.2.0"
@@ -4278,3 +4232,8 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,51 @@
 # yarn lockfile v1
 
 
+"@ava/babel@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ava/babel/-/babel-1.0.1.tgz#9f005bc0118eee4639827df798c75b77fa5fe35d"
+  integrity sha512-mGKpGeT6J4UjK2sxPjvwWl/GtsF9+eNyn2HHa7OknWWWYuw+rof/UaTAn1CA0z4sTw4Mruik/ihEasMw+JM6aQ==
+  dependencies:
+    "@ava/require-precompiled" "^1.0.0"
+    "@babel/core" "^7.8.4"
+    "@babel/generator" "^7.8.4"
+    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.8.3"
+    "@babel/plugin-transform-modules-commonjs" "^7.8.3"
+    babel-plugin-espower "^3.0.1"
+    concordance "^4.0.0"
+    convert-source-map "^1.7.0"
+    dot-prop "^5.2.0"
+    empower-core "^1.2.0"
+    escape-string-regexp "^2.0.0"
+    find-up "^4.1.0"
+    is-plain-object "^3.0.0"
+    md5-hex "^3.0.1"
+    package-hash "^4.0.0"
+    pkg-conf "^3.1.0"
+    source-map-support "^0.5.16"
+    strip-bom-buf "^2.0.0"
+    write-file-atomic "^3.0.1"
+
+"@ava/require-precompiled@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ava/require-precompiled/-/require-precompiled-1.0.0.tgz#6f4a48b75904a753eadff020bbfca81d3bbc0357"
+  integrity sha512-N7w4g+P/SUL8SF+HC4Z4e/ctV6nQ5AERC90K90r4xZQ8WVrJux9albvfyYAzygyU47CSqMWh6yJwFs8DYaeWmg==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
   integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
   dependencies:
     "@babel/highlight" "^7.8.3"
+
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  dependencies:
+    "@babel/highlight" "^7.12.13"
 
 "@babel/core@^7.7.5":
   version "7.8.3"
@@ -30,6 +69,36 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.8.4":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.13.tgz#b73a87a3a3e7d142a66248bf6ad88b9ceb093425"
+  integrity sha512-BQKE9kXkPlXHPeqissfxo0lySWJcYdEP0hdtJOH/iJfDdhOCcgtNCjftCJg3qqauB4h+lz2N6ixM++b9DN1Tcw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.12.13"
+    "@babel/helper-module-transforms" "^7.12.13"
+    "@babel/helpers" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@babel/types" "^7.12.13"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.0.0", "@babel/generator@^7.12.13", "@babel/generator@^7.8.4":
+  version "7.12.15"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.15.tgz#4617b5d0b25cc572474cc1aafee1edeaf9b5368f"
+  integrity sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==
+  dependencies:
+    "@babel/types" "^7.12.13"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
@@ -40,6 +109,15 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/helper-function-name@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
+  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -49,6 +127,13 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-get-function-arity@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
+  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
@@ -56,12 +141,98 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz#c5715695b4f8bab32660dbdcdc2341dec7e3df40"
+  integrity sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
+"@babel/helper-module-imports@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
+  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
+"@babel/helper-module-transforms@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz#01afb052dcad2044289b7b20beb3fa8bd0265bea"
+  integrity sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.12.13"
+    "@babel/helper-simple-access" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@babel/types" "^7.12.13"
+    lodash "^4.17.19"
+
+"@babel/helper-optimise-call-expression@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
+  integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
+"@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz#174254d0f2424d8aefb4dd48057511247b0a9eeb"
+  integrity sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==
+
+"@babel/helper-replace-supers@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz#00ec4fb6862546bd3d0aff9aac56074277173121"
+  integrity sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.13"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
+"@babel/helper-simple-access@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz#8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4"
+  integrity sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
+  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
+"@babel/helper-split-export-declaration@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
+  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
+"@babel/helpers@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.13.tgz#3c75e993632e4dadc0274eae219c73eb7645ba47"
+  integrity sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==
+  dependencies:
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@babel/types" "^7.12.13"
 
 "@babel/helpers@^7.8.3":
   version "7.8.3"
@@ -72,6 +243,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/highlight@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
+  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
@@ -81,10 +261,80 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.0.0", "@babel/parser@^7.12.13":
+  version "7.12.15"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.15.tgz#2b20de7f0b4b332d9b119dd9c33409c538b8aacf"
+  integrity sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==
+
 "@babel/parser@^7.7.5", "@babel/parser@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+
+"@babel/plugin-proposal-dynamic-import@^7.8.3":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz#43eb5c2a3487ecd98c5c8ea8b5fdb69a2749b2dc"
+  integrity sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.13.tgz#24867307285cee4e1031170efd8a7ac807deefde"
+  integrity sha512-Qoxpy+OxhDBI5kRqliJFAl4uWXk3Bn24WeFstPH0iLymFehSAUR8MHpqU7njyXv/qbo7oN6yTy5bfCmXdKpo1Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.8.3":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.13.tgz#63a7d805bc8ce626f3234ee5421a2a7fb23f66d9"
+  integrity sha512-0ZwjGfTcnZqyV3y9DSD1Yk3ebp+sIUpT2YDqP8hovzaNZnQq2Kd7PEqa6iOIUDBXBt7Jl3P7YAcEIL5Pz8u09Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
+"@babel/plugin-syntax-dynamic-import@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
+  integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.8.3":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.13.tgz#5043b870a784a8421fa1fd9136a24f294da13e50"
+  integrity sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-simple-access" "^7.12.13"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/template@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
+  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/types" "^7.12.13"
 
 "@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
@@ -94,6 +344,21 @@
     "@babel/code-frame" "^7.8.3"
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/traverse@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.13.tgz#689f0e4b4c08587ad26622832632735fb8c4e0c0"
+  integrity sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.12.13"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/types" "^7.12.13"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
 
 "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3":
   version "7.8.3"
@@ -109,6 +374,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
+
+"@babel/types@^7.12.1", "@babel/types@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
+  integrity sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.8.3":
   version "7.8.3"
@@ -258,13 +532,6 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/murmurhash3js/-/murmurhash3js-3.0.2.tgz#eeaf46ed69b0e473f0c310a383c9362c299981f7"
   integrity sha512-xx8QZPFSzd5520I/EVZCNYUEzTPHYkKf+V0CBDPMA/X0vRRQRkFiEjTfoM3Yd+oE0jTKR/qZ+vDWF+2PMaVXMg==
-
-"@types/nock@^11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
-  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
-  dependencies:
-    nock "*"
 
 "@types/node-fetch@^2.5.8":
   version "2.5.8"
@@ -561,11 +828,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
-
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -647,6 +909,26 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+babel-plugin-dynamic-import-node@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
+  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
+  dependencies:
+    object.assign "^4.1.0"
+
+babel-plugin-espower@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz#180db17126f88e754105b8b5216d21e520a6bd4e"
+  integrity sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==
+  dependencies:
+    "@babel/generator" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    call-matcher "^1.0.0"
+    core-js "^2.0.0"
+    espower-location-detector "^1.0.0"
+    espurify "^1.6.0"
+    estraverse "^4.1.1"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -757,6 +1039,21 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-matcher@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/call-matcher/-/call-matcher-1.1.0.tgz#23b2c1bc7a8394c8be28609d77ddbd5786680432"
+  integrity sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==
+  dependencies:
+    core-js "^2.0.0"
+    deep-equal "^1.0.0"
+    espurify "^1.6.0"
+    estraverse "^4.0.0"
+
+call-signature@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
+  integrity sha1-qEq8glpV70yysCi9dOIFpluaSZY=
+
 callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -777,18 +1074,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chai@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.0"
-    type-detect "^4.0.5"
-
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -805,11 +1090,6 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-check-error@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@^3.4.3:
   version "3.5.1"
@@ -976,6 +1256,23 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+concordance@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/concordance/-/concordance-4.0.0.tgz#5932fdee397d129bdbc3a1885fbe69839b1b7e15"
+  integrity sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==
+  dependencies:
+    date-time "^2.1.0"
+    esutils "^2.0.2"
+    fast-diff "^1.1.2"
+    js-string-escape "^1.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.flattendeep "^4.4.0"
+    lodash.islength "^4.0.1"
+    lodash.merge "^4.6.1"
+    md5-hex "^2.0.0"
+    semver "^5.5.1"
+    well-known-symbols "^2.0.0"
+
 concordance@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/concordance/-/concordance-5.0.1.tgz#7a248aca8b286125d1d76f77b03320acf3f4ac63"
@@ -1023,6 +1320,11 @@ convert-to-spaces@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
   integrity sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=
+
+core-js@^2.0.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -1104,6 +1406,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-time@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
+  integrity sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==
+  dependencies:
+    time-zone "^1.0.0"
+
 date-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-3.1.0.tgz#0d1e934d170579f481ed8df1e2b8ff70ee845e1e"
@@ -1149,12 +1458,17 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-eql@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+deep-equal@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
   dependencies:
-    type-detect "^4.0.0"
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1272,6 +1586,14 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+empower-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/empower-core/-/empower-core-1.2.0.tgz#ce3fb2484d5187fa29c23fba8344b0b2fdf5601c"
+  integrity sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==
+  dependencies:
+    call-signature "0.0.2"
+    core-js "^2.0.0"
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -1505,6 +1827,16 @@ esm@^3.2.25:
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
+espower-location-detector@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/espower-location-detector/-/espower-location-detector-1.0.0.tgz#a17b7ecc59d30e179e2bef73fb4137704cb331b5"
+  integrity sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=
+  dependencies:
+    is-url "^1.2.1"
+    path-is-absolute "^1.0.0"
+    source-map "^0.5.0"
+    xtend "^4.0.0"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -1518,6 +1850,13 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+espurify@^1.6.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/espurify/-/espurify-1.8.1.tgz#5746c6c1ab42d302de10bd1d5bf7f0e8c0515056"
+  integrity sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==
+  dependencies:
+    core-js "^2.0.0"
 
 esquery@^1.2.0:
   version "1.4.0"
@@ -1533,7 +1872,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -1762,11 +2101,6 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
   version "1.1.1"
@@ -2070,6 +2404,13 @@ irregular-plurals@^3.2.0:
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.2.0.tgz#b19c490a0723798db51b235d7e39add44dab0822"
   integrity sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==
 
+is-arguments@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2188,6 +2529,11 @@ is-path-inside@^3.0.2:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
+is-plain-object@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
+  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
+
 is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
@@ -2198,7 +2544,7 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
-is-regex@^1.1.1:
+is-regex@^1.0.4, is-regex@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
   integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
@@ -2232,6 +2578,16 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
+is-utf8@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -2412,6 +2768,13 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2546,6 +2909,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -2555,6 +2923,16 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.islength@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.islength/-/lodash.islength-4.0.1.tgz#4e9868d452575d750affd358c979543dc20ed577"
+  integrity sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=
+
+lodash.merge@^4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -2566,7 +2944,7 @@ lodash@^4.17.13, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.20:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -2631,12 +3009,24 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+md5-hex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-2.0.0.tgz#d0588e9f1c74954492ecd24ac0ac6ce997d92e33"
+  integrity sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=
+  dependencies:
+    md5-o-matic "^0.1.1"
+
 md5-hex@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c"
   integrity sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==
   dependencies:
     blueimp-md5 "^2.10.0"
+
+md5-o-matic@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+  integrity sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=
 
 mem@^8.0.0:
   version "8.0.0"
@@ -2698,11 +3088,6 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
@@ -2712,13 +3097,6 @@ minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-mkdirp@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -2760,18 +3138,6 @@ nise@^4.0.4:
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
-
-nock@*:
-  version "11.3.5"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-11.3.5.tgz#f2c7b4b672a04c35342593b6bfd821497881199c"
-  integrity sha512-6WGeZcWc3RExkBcMSYSrUm/5YukDo52m/jhwniQyrnuiCnKRljBwwje9vTwJyEi4J6m2bq0Aj6C1vzuM6iuaeg==
-  dependencies:
-    chai "^4.1.2"
-    debug "^4.1.0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.13"
-    mkdirp "^0.5.0"
-    propagate "^2.0.0"
 
 nock@^13.0.7:
   version "13.0.7"
@@ -2865,12 +3231,20 @@ object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
 
+object-is@^1.0.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.2:
+object.assign@^4.1.0, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -3148,11 +3522,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -3350,6 +3719,14 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+regexp.prototype.flags@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -3539,7 +3916,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
   integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3632,7 +4009,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-support@^0.5.19:
+source-map-support@^0.5.16, source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -3783,6 +4160,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-bom-buf@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz#ff9c223937f8e7154b77e9de9bde094186885c15"
+  integrity sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==
+  dependencies:
+    is-utf8 "^0.2.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -3949,7 +4333,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -4155,7 +4539,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-write-file-atomic@^3.0.3:
+write-file-atomic@^3.0.1, write-file-atomic@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
@@ -4169,6 +4553,11 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Migrating from eslint-config-finn to eslint-config-airbnb
  and enabling airbnb typescript as well.
- Fixes needed to get this to run without warnings.
  There is one dependency cycle between variants and feature that I
  couldn't find a way to untangle for now.
- AirBnb also fails on more than one class per file, so extracted some
  of our test classes to separate files.
- Run eslint . -fix
- Upgrade ava, and tell ava about our project configs of jsconfig and
  tsconfig.