### PR TITLE
Normalized stickiness case to work properly with Gitlab

### DIFF
--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -19,7 +19,7 @@ export default class FlexibleRolloutStrategy extends Strategy {
   }
 
   resolveStickiness(stickiness: string, context: Context): any {
-    const stickinessNormalized = stickiness?.toLowerCase()
+    const stickinessNormalized = stickiness?.toLowerCase();
     switch (stickinessNormalized) {
       case STICKINESS.default:
         return context.userId || context.sessionId || this.randomGenerator();

--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -19,7 +19,8 @@ export default class FlexibleRolloutStrategy extends Strategy {
   }
 
   resolveStickiness(stickiness: string, context: Context): any {
-    switch (stickiness) {
+    const stickinessNormalized = stickiness?.toLowerCase()
+    switch (stickinessNormalized) {
       case STICKINESS.default:
         return context.userId || context.sessionId || this.randomGenerator();
       case STICKINESS.random:


### PR DESCRIPTION
Gitlab send stickiness for strategies un uppercase, this small PR normalizes the name and makes it work with Unleash integrated in gitlab. 