### PR TITLE
Add Support for Passing an HTTP Arguments Option for rejectUnauthorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The initialize method takes the following arguments:
   option.
 - **timeout** - specify a timeout in milliseconds for outgoing HTTP requests. Defaults to 10000ms.
 - **repository** - Provide a custom repository implementation to manage the underlying data
+- **httpOptions** - Provide custom http options such as `rejectUnauthorized` - be careful with these
+  options as they may compromise your application security
 
 ## Custom strategies
 

--- a/src/http-options.ts
+++ b/src/http-options.ts
@@ -1,0 +1,3 @@
+export interface HttpOptions {
+  rejectUnauthorized?: boolean;
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -3,6 +3,7 @@ import { resolve } from 'url';
 import { post, Data } from './request';
 import { CustomHeaders, CustomHeadersFunction } from './headers';
 import { sdkVersion } from './details.json';
+import { HttpOptions } from './http-options';
 
 export interface MetricsOptions {
   appName: string;
@@ -15,6 +16,7 @@ export interface MetricsOptions {
   headers?: CustomHeaders;
   customHeadersFunction?: CustomHeadersFunction;
   timeout?: number;
+  httpOptions?: HttpOptions;
 }
 
 interface VariantBucket {
@@ -56,6 +58,8 @@ export default class Metrics extends EventEmitter {
 
   private timeout?: number;
 
+  private httpOptions?: HttpOptions;
+
   constructor({
     appName,
     instanceId,
@@ -66,6 +70,7 @@ export default class Metrics extends EventEmitter {
     headers,
     customHeadersFunction,
     timeout,
+    httpOptions,
   }: MetricsOptions) {
     super();
     this.disabled = disableMetrics;
@@ -80,6 +85,7 @@ export default class Metrics extends EventEmitter {
     this.started = new Date();
     this.timeout = timeout;
     this.resetBucket();
+    this.httpOptions = httpOptions;
 
     if (typeof this.metricsInterval === 'number' && this.metricsInterval > 0) {
       this.startTimer();
@@ -126,6 +132,7 @@ export default class Metrics extends EventEmitter {
         instanceId: this.instanceId,
         headers,
         timeout: this.timeout,
+        httpOptions: this.httpOptions,
       });
       if (!res.ok) {
         // status code outside 200 range
@@ -162,6 +169,7 @@ export default class Metrics extends EventEmitter {
         instanceId: this.instanceId,
         headers,
         timeout: this.timeout,
+        httpOptions: this.httpOptions,
       });
       this.startTimer();
       if (res.status === 404) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,6 +4,7 @@ import { FeatureInterface } from './feature';
 import { get } from './request';
 import { CustomHeaders, CustomHeadersFunction } from './headers';
 import getUrl from './url-utils';
+import { HttpOptions } from './http-options';
 
 export type StorageImpl = typeof Storage;
 
@@ -24,6 +25,7 @@ export interface RepositoryOptions {
   timeout?: number;
   headers?: CustomHeaders;
   customHeadersFunction?: CustomHeadersFunction;
+  httpOptions?: HttpOptions;
 }
 
 export default class Repository extends EventEmitter implements EventEmitter {
@@ -51,6 +53,8 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
   private projectName?: string;
 
+  private httpOptions?: HttpOptions;
+
   constructor({
     backupPath,
     url,
@@ -62,6 +66,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     timeout,
     headers,
     customHeadersFunction,
+    httpOptions,
   }: RepositoryOptions) {
     super();
     this.url = url;
@@ -72,6 +77,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     this.headers = headers;
     this.timeout = timeout;
     this.customHeadersFunction = customHeadersFunction;
+    this.httpOptions = httpOptions;
 
     this.storage = new StorageImpl({ backupPath, appName });
     this.storage.on('error', (err) => this.emit('error', err));
@@ -128,6 +134,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
         timeout: this.timeout,
         instanceId: this.instanceId,
         headers,
+        httpOptions: this.httpOptions,
       });
 
       if (res.status === 304) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,6 +3,7 @@ import * as http from 'http';
 import * as https from 'https';
 import { URL } from 'url';
 import { CustomHeaders } from './headers';
+import { HttpOptions } from './http-options';
 
 export interface RequestOptions {
   url: string;
@@ -14,6 +15,7 @@ export interface GetRequestOptions extends RequestOptions {
   etag?: string;
   appName?: string;
   instanceId?: string;
+  httpOptions?: HttpOptions;
 }
 
 export interface Data {
@@ -24,6 +26,7 @@ export interface PostRequestOptions extends RequestOptions {
   json: Data;
   appName?: string;
   instanceId?: string;
+  httpOptions?: HttpOptions;
 }
 const httpAgent = new http.Agent({
   keepAlive: true,
@@ -65,16 +68,33 @@ export const buildHeaders = (
   return head;
 };
 
-export const post = ({ url, appName, timeout, instanceId, headers, json }: PostRequestOptions) =>
+export const post = ({
+  url,
+  appName,
+  timeout,
+  instanceId,
+  headers,
+  json,
+  httpOptions,
+}: PostRequestOptions) =>
   fetch(url, {
     timeout: timeout || 10000,
     method: 'POST',
     agent: getAgent,
     headers: buildHeaders(appName, instanceId, undefined, 'application/json', headers),
     body: JSON.stringify(json),
+    strictSSL: httpOptions?.rejectUnauthorized,
   });
 
-export const get = ({ url, etag, appName, timeout, instanceId, headers }: GetRequestOptions) =>
+export const get = ({
+  url,
+  etag,
+  appName,
+  timeout,
+  instanceId,
+  headers,
+  httpOptions,
+}: GetRequestOptions) =>
   fetch(url, {
     method: 'GET',
     timeout: timeout || 10000,
@@ -83,4 +103,5 @@ export const get = ({ url, etag, appName, timeout, instanceId, headers }: GetReq
     retry: {
       retries: 2,
     },
+    strictSSL: httpOptions?.rejectUnauthorized,
   });

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -10,6 +10,7 @@ import { Strategy, defaultStrategies } from './strategy';
 import { FeatureInterface } from './feature';
 import { Variant, getDefaultVariant } from './variant';
 import { FallbackFunction, createFallbackFunction } from './helpers';
+import { HttpOptions } from './http-options';
 
 export { Strategy };
 
@@ -30,6 +31,7 @@ export interface UnleashConfig {
   customHeadersFunction?: CustomHeadersFunction;
   timeout?: number;
   repository?: RepositoryInterface;
+  httpOptions?: HttpOptions;
 }
 
 export interface StaticContext {
@@ -63,6 +65,7 @@ export class Unleash extends EventEmitter {
     customHeaders,
     customHeadersFunction,
     timeout,
+    httpOptions,
   }: UnleashConfig) {
     super();
 
@@ -118,6 +121,7 @@ export class Unleash extends EventEmitter {
         headers: customHeaders,
         customHeadersFunction,
         timeout,
+        httpOptions,
       });
 
     const strats = defaultStrategies.concat(strategies);
@@ -165,6 +169,7 @@ export class Unleash extends EventEmitter {
       headers: customHeaders,
       customHeadersFunction,
       timeout,
+      httpOptions,
     });
 
     this.metrics.on('error', (err) => {


### PR DESCRIPTION
For #226  

Add ability to pass in an `HttpOptions` object with, as of now, only one field `rejectUnauthorized` to help with custom ca certs. The object was created if in the future other options need to be passed in such as an actual ca cert file, custom headers, proxy settings, etc. 