### PR TITLE
Changed the priority of the strategy block

### DIFF
--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -124,7 +124,7 @@ export class Unleash extends EventEmitter {
         httpOptions,
       });
 
-    const strats = defaultStrategies.concat(strategies);
+    const strats = strategies.concat(defaultStrategies);
 
     this.repository.on('ready', () => {
       this.client = new Client(this.repository, strats);


### PR DESCRIPTION
**Problem, for example:**
It is necessary to change the logic of the `userWithId` strategy

In `client.ts`, the search for the current strategy is done using
```
return this.strategies.find ((strategy: Strategy): boolean => strategy.name === name);
```

**Solution**
Change the order of the merge
```
const strats = strategies.concat(defaultStrategies);
```

Thus, by changing the order of merging strategies, we are able to find our changed strategy with the name `userWithId`, if we embrace it in the configuration:
```
const client = initialize({
...
  strategies: [new UserWithIdStrategy()],
...
});
```