### PR TITLE
Add forceGetVariant method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,12 @@ import InMemStorageProvider from './repository/storage-provider-in-mem'
 // exports
 export { Strategy } from './strategy/index';
 export { Context, Variant, Unleash, TagFilter, InMemStorageProvider, UnleashEvents };
-export type { ClientFeaturesResponse, UnleashConfig }; 
+export type { ClientFeaturesResponse, UnleashConfig };
 
 let instance: Unleash | undefined;
 export function initialize(options: UnleashConfig): Unleash {
   if (instance) {
-    instance.emit(UnleashEvents.Warn, 
+    instance.emit(UnleashEvents.Warn,
       'This global unleash instance is initialized multiple times.');
   }
   instance = new Unleash(options);
@@ -52,6 +52,15 @@ export function getVariant(
 ): Variant {
   const variant = fallbackVariant || getDefaultVariant();
   return instance ? instance.getVariant(name, context, variant) : variant;
+}
+
+export function forceGetVariant(
+  name: string,
+  context: Context = {},
+  fallbackVariant?: Variant,
+): Variant {
+  const variant = fallbackVariant || getDefaultVariant();
+  return instance ? instance.forceGetVariant(name, context, variant) : variant;
 }
 
 export function count(toggleName: string, enabled: boolean) {


### PR DESCRIPTION
Adds a forceGetVariant method which will not check the state of the parent toggle when called. This is to fix an issue in the ProxySDK, which currently resolves variant enabled state twice, which causes the % of a given variant to incorrectly resolve.

This isn't covered with unit tests, if someone can suggest a viable unit/integration test that would be great, given the statistically variant nature of the issue, it has been manually tested by manually linking the proxy sdk with the following Python script and checking visually that the distributions are within tolerance:

```
import requests

max_requests = 100

no_toggles = 0
disabled_variant = 0
var1 = 0
var2 = 0

for i in range(0, max_requests):
    r = requests.get('http://localhost:3000/proxy', headers={"Authorization":"proxy-secret"})
    response = r.json()
    toggles = response["toggles"]

    if toggles:
        toggle = toggles[0]
        variant = toggle.get('variant')
        if variant:
            name = variant.get('name')
            if name == "disabled":
                disabled_variant += 1
            elif name == "Var1":
                var1 += 1
            elif name == "Var2":
                var2 += 1
            else:
                raise Exception("Unexpected variant")
    else:
        no_toggles += 1
print("No toggles:", no_toggles, no_toggles/max_requests)
print("Disabled variant:", disabled_variant, disabled_variant/max_requests)
print("Var1:", var1, var1/max_requests)
print("Var2:", var2, var2/max_requests)
print("---")
print("Total:", (var1 + var2 + no_toggles + disabled_variant)/max_requests)
```
