### PR TITLE
fix: Cannot read property 'split' of undefined in UserWithIdStrategy

### DIFF
--- a/src/strategy/user-with-id-strategy.ts
+++ b/src/strategy/user-with-id-strategy.ts
@@ -7,7 +7,7 @@ export default class UserWithIdStrategy extends Strategy {
   }
 
   isEnabled(parameters: any, context: Context) {
-    const userIdList = parameters.userIds.split(/\s*,\s*/);
+    const userIdList = parameters.userIds ? parameters.userIds.split(/\s*,\s*/) : [];
     return userIdList.includes(context.userId);
   }
 }

--- a/test/strategy/user-with-id-strategy.test.js
+++ b/test/strategy/user-with-id-strategy.test.js
@@ -5,6 +5,7 @@ import UserWithIdStrategy from '../../lib/strategy/user-with-id-strategy';
 test('default strategy should have correct name', (t) => {
   const strategy = new UserWithIdStrategy();
   t.deepEqual(strategy.name, 'userWithId');
+  t.false(strategy.isEnabled({}, {}));
 });
 
 test('user-with-id-strategy should be enabled for userId', (t) => {


### PR DESCRIPTION
Fix error when reading an empty UserWithIdStrategy in client.

```
Client.getEnabledToggles (/unleash-proxy/dist/client.js:68:14)
Array.filter (<anonymous>)
/unleash-proxy/dist/client.js:68:41
Unleash.isEnabled (/unleash-proxy/node_modules/unleash-client/lib/unleash.js:209:34)
UnleashClient.isEnabled (/unleash-proxy/node_modules/unleash-client/lib/client.js:54:21)
UnleashClient.isFeatureEnabled (/unleash-proxy/node_modules/unleash-client/lib/client.js:72:32)
Array.some (<anonymous>)
/unleash-proxy/node_modules/unleash-client/lib/client.js:78:33
UserWithIdStrategy.Strategy.isEnabledWithConstraints (/unleash-proxy/node_modules/unleash-client/lib/strategy/strategy.js:159:68)
UserWithIdStrategy.isEnabled (/unleash-proxy/node_modules/unleash-client/lib/strategy/user-with-id-strategy.js:25:45)
TypeError: Cannot read property 'split' of undefined
```
