### PR TITLE
Update Documentation - Clearer client alternative usage and highlight the require use of error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,27 @@ unleash.on('synchronized', () => {
   const variant = unleash.getVariant('app.ToggleY');
 });
 ```
+Be aware that the `initialize` function will configure a _global_ Unleash instance. If you call this method multiple times the global instance will be changed. 
 
-Be aware that the `initialize` function will configure a _global_ Unleash instance. If you call this
-method multiple times the global instance will be changed. If you prefer to handle the instance
-yourself you should [construct your own Unleash instance](#alternative-usage).
+#### <u>Constructing the Unleash client directly</u>
+If you prefer to construct the Unleash instance yourself rather than using the global `initialize` method you can do so e.g.:
+```js
+const { Unleash } = require('unleash-client');
+
+const unleash = new Unleash({
+  appName: 'my-app-name',
+  url: 'http://unleash.herokuapp.com',
+  customHeaders: {
+    Authorization: 'API token',
+  },
+});
+
+unleash.on('ready', console.log.bind(console, 'ready'));
+
+// required error handling when using unleash directly  
+unleash.on('error', console.error);
+```
+**_IMPORTANT:_** When using unleash directly, error handling is required by adding an event listener for the error event. Otherwise your application may either not start up, or crash if its running when the application can't reach the unleash server.
 
 #### Block until Unleash SDK has synchronized
 
@@ -164,27 +181,6 @@ initialize({
   },
   strategies: [new ActiveForUserWithEmailStrategy()],
 });
-```
-
-## Alternative usage
-
-Its also possible to ship the unleash instance around yourself, instead of using on the default
-`require.cache` to have share one instance.
-
-```js
-const { Unleash } = require('unleash-client');
-
-const unleash = new Unleash({
-  appName: 'my-app-name',
-  url: 'http://unleash.herokuapp.com',
-  customHeaders: {
-    Authorization: 'API token',
-  },
-});
-
-unleash.on('ready', console.log.bind(console, 'ready'));
-// required error handling when using unleash directly
-unleash.on('error', console.error);
 ```
 
 ## Events

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ unleash.on('ready', console.log.bind(console, 'ready'));
 // required error handling when using unleash directly  
 unleash.on('error', console.error);
 ```
-**_IMPORTANT:_** When using unleash directly, error handling is required by adding an event listener for the error event. Otherwise your application may either not start up, or crash if its running when the application can't reach the unleash server.
+**Important:** When Using unleash directly, you **must** handle errors yourself. This can be done by attaching an event listener to the `error` event, as shown in the example below. If you don't do this, your application may crash either on startup or at runtime if it can't reach the Unleash server or if it encounters other errors.
 
 #### Block until Unleash SDK has synchronized
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ unleash.on('synchronized', () => {
 ```
 Be aware that the `initialize` function will configure a _global_ Unleash instance. If you call this method multiple times the global instance will be changed. 
 
-#### <u>Constructing the Unleash client directly</u>
+#### Constructing the Unleash client directly
 If you prefer to construct the Unleash instance yourself rather than using the global `initialize` method you can do so e.g.:
 ```js
 const { Unleash } = require('unleash-client');


### PR DESCRIPTION
## Background
PR based on the issue here https://github.com/Unleash/unleash-client-node/issues/310

## What's Done
* Move the alternative usage section further up in the documentation as a subsection of the Initialize unleash-client section.
* Highlight in a note that when using unleash directly, that its required to add an event listener and if it is not done the application may either not start up or crash if it can't reach the unleash server.
* Remove defunct note about `require.cache`