### PR TITLE
fix: Use string[] instead of String[] for Override values

### DIFF
--- a/src/variant.ts
+++ b/src/variant.ts
@@ -10,7 +10,7 @@ enum PayloadType {
 
 interface Override {
   contextName: string;
-  values: String[];
+  values: string[];
 }
 
 export interface Payload {


### PR DESCRIPTION
This PR changes the use of `String[]` to the use of `string[]` in the variant type definition. It is assumed that this is just done in error and doesn't actually carry any meaning.

This seems to be the only case where we're using uppercase Strings.
It's causing issues with OpenAPI typing, which says that String is not
string and that it can't compile with this issue.