### PR TITLE
Type is missing from FeatureInterface

### DIFF
--- a/src/feature.ts
+++ b/src/feature.ts
@@ -4,6 +4,7 @@ import { VariantDefinition } from './variant';
 
 export interface FeatureInterface {
   name: string;
+  type: string;
   description?: string;
   enabled: boolean;
   stale: boolean;


### PR DESCRIPTION
The FeatureInterface was missing the type member, despite the data containing it when using the getFeatureDefinitions function. 

I'm making a feature where an app gets all feature toggles of type experiment with a certain naming scheme. And it would be nice to use the type member without creating an extension interface in my code.
