### PR TITLE
feat: pass spec header so global segments can be toggled

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -10,6 +10,8 @@ import { StorageProvider } from './storage-provider';
 import { UnleashEvents } from '../events';
 import { Segment } from '../strategy/strategy';
 
+const SUPPORTED_SPEC_VERSION = '4.2.0';
+
 export interface RepositoryInterface extends EventEmitter {
   getToggle(name: string): FeatureInterface;
   getToggles(): FeatureInterface[];
@@ -263,6 +265,7 @@ Message: ${err.message}`,
         instanceId: this.instanceId,
         headers,
         httpOptions: this.httpOptions,
+        supportedSpecVersion: SUPPORTED_SPEC_VERSION,
       });
 
       if (res.status === 304) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -15,6 +15,7 @@ export interface GetRequestOptions extends RequestOptions {
   etag?: string;
   appName?: string;
   instanceId?: string;
+  supportedSpecVersion?: string;
   httpOptions?: HttpOptions;
 }
 
@@ -47,6 +48,7 @@ export const buildHeaders = (
   etag?: string,
   contentType?: string,
   custom?: CustomHeaders,
+  specVersionSupported?: string,
 ): Record<string, string> => {
   const head: Record<string, string> = {};
   if (appName) {
@@ -61,6 +63,9 @@ export const buildHeaders = (
   }
   if (contentType) {
     head['Content-Type'] = contentType;
+  }
+  if (specVersionSupported) {
+    head['Unleash-Client-Spec'] = specVersionSupported;
   }
   if (custom) {
     Object.assign(head, custom);
@@ -94,12 +99,13 @@ export const get = ({
   instanceId,
   headers,
   httpOptions,
+  supportedSpecVersion,
 }: GetRequestOptions) =>
   fetch(url, {
     method: 'GET',
     timeout: timeout || 10_000,
     agent: httpOptions?.agent || getDefaultAgent,
-    headers: buildHeaders(appName, instanceId, etag, undefined, headers),
+    headers: buildHeaders(appName, instanceId, etag, undefined, headers, supportedSpecVersion),
     retry: {
       retries: 2,
       maxTimeout: timeout || 10_000,

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -248,7 +248,7 @@ export class Unleash extends EventEmitter {
     }
     if (result.name) {
       this.countVariant(name, result.name);
-    } 
+    }
     this.count(name, result.enabled);
 
     return result;


### PR DESCRIPTION
Adds the client spec header so that unleash can determine whether to inline segments or not, related to this PR: https://github.com/Unleash/unleash/pull/1640 that implements the change server side