### PR TITLE
Use fallback value if not initialised

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,11 +31,10 @@ export function safeName(str: string = '') {
   return str.replace(/\//g, '_');
 }
 
-
 export function generateInstanceId(instanceId?: string): string {
-  if(instanceId) {
+  if (instanceId) {
     return instanceId;
-  } 
+  }
   let info;
   try {
     info = userInfo();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Context } from './context';
 import { TagFilter } from './tags';
 import { UnleashEvents } from './events';
 import { ClientFeaturesResponse } from './feature';
-import InMemStorageProvider from './repository/storage-provider-in-mem'
+import InMemStorageProvider from './repository/storage-provider-in-mem';
 
 // exports
 export { Strategy } from './strategy/index';
@@ -15,8 +15,10 @@ export type { ClientFeaturesResponse, UnleashConfig };
 let instance: Unleash | undefined;
 export function initialize(options: UnleashConfig): Unleash {
   if (instance) {
-    instance.emit(UnleashEvents.Warn,
-      'This global unleash instance is initialized multiple times.');
+    instance.emit(
+      UnleashEvents.Warn,
+      'This global unleash instance is initialized multiple times.',
+    );
   }
   instance = new Unleash(options);
   instance.on('error', () => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export async function startUnleash(options: UnleashConfig): Promise<Unleash> {
 }
 
 export function isEnabled(name: string, context: Context = {}, fallbackValue?: boolean): boolean {
-  return !!instance && instance.isEnabled(name, context, fallbackValue);
+  return instance ? instance.isEnabled(name, context, fallbackValue) : !!fallbackValue;
 }
 
 export function destroy() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,10 @@ export function isEnabled(name: string, context: Context = {}, fallbackValue?: b
 }
 
 export function destroy() {
-  return instance && instance.destroy();
+  if (instance ) {
+    instance.destroy();
+  }
+  instance = undefined;
 }
 
 export function getFeatureToggleDefinition(toggleName: string) {

--- a/src/repository/storage-provider.ts
+++ b/src/repository/storage-provider.ts
@@ -17,14 +17,14 @@ export class FileStorageProvider<T> implements StorageProvider<T> {
   private backupPath: string;
 
   constructor(backupPath: string) {
-    if(!backupPath) {
-      throw new Error("backup Path is required");
+    if (!backupPath) {
+      throw new Error('backup Path is required');
     }
     this.backupPath = backupPath;
   }
 
   private getPath(key: string): string {
-    return join(this.backupPath, `/unleash-backup-${safeName(key)}.json`)
+    return join(this.backupPath, `/unleash-backup-${safeName(key)}.json`);
   }
 
   async set(key: string, data: T): Promise<void> {
@@ -44,8 +44,8 @@ export class FileStorageProvider<T> implements StorageProvider<T> {
       }
     }
 
-    if(!data || data.trim().length === 0) {
-        return undefined;
+    if (!data || data.trim().length === 0) {
+      return undefined;
     }
 
     try {

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -63,3 +63,10 @@ test.cb('should be able to call isEnabled eventually', (t) => {
 
   t.true(isEnabled('feature') === false);
 });
+
+test.cb('should return fallbackValue if init was not called', (t) => {
+  t.true(isEnabled('feature') === false);
+  t.true(isEnabled('feature', {}, false) === false);
+  t.true(isEnabled('feature', {}, true) === true);
+  t.end();
+})


### PR DESCRIPTION
## About the changes
* The first commit fixes prettier issues on the current main branch. If wanted, I could remove this commit from my PR.
* The second commit sets the instance global to `undefined` on `destroy()`. This is required to make the tests in the third command work. I don’t think this is braking, since it would be the expected behaviour anyway.
* The third commit introduces the actual fix and sets the `fallbackValue` if the instance was not initialised before. (Tests including). For details see #338. 

Closes #338 

## Discussion points

* Should prettier changes to related to fix be included in this PR?
