### PR TITLE
fix: NOT_IN operator for missing contextField should return true.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/node": "14.18.16",
     "@types/semver": "7.3.9",
     "@typescript-eslint/eslint-plugin": "5.10.0",
-    "@unleash/client-specification": "4.2.0",
+    "@unleash/client-specification": "4.2.1",
     "ava": "3.15.0",
     "coveralls": "3.1.1",
     "cross-env": "7.0.3",

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -54,11 +54,9 @@ const InOperator = (constraint: Constraint, context: Context) => {
   const field = constraint.contextName;
   const values = cleanValues(constraint.values);
   const contextValue = resolveContextValue(context, field);
-  if (!contextValue) {
-    return false;
-  }
 
   const isIn = values.some((val) => val === contextValue);
+  
   return constraint.operator === Operator.IN ? isIn : !isIn;
 };
 

--- a/test/strategy/strategy-test.js
+++ b/test/strategy/strategy-test.js
@@ -515,3 +515,27 @@ test('should return false when passed an invalid semver', (t) => {
   };
   t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 })
+
+test('should NOT be enabled for unknown field', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [{ contextName: 'someField', operator: 'IN', values: ['s1'] }];
+  const context = { };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+});
+
+test('should be enabled for undefined field when NOT_IN', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [{ contextName: 'someField', operator: 'NOT_IN', values: ['s1'] }];
+  const context = { properties: { someField: undefined } };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+});
+
+test('should be enabled for missing field when NOT_IN', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [{ contextName: 'someField', operator: 'NOT_IN', values: ['s1'] }];
+  const context = { };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@
     "@typescript-eslint/types" "5.10.0"
     eslint-visitor-keys "^3.0.0"
 
-"@unleash/client-specification@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@unleash/client-specification/-/client-specification-4.2.0.tgz#f03c9c62f01a0e9005367b9d8ab91219d5d49c78"
-  integrity sha512-LPszGRb4sTdV2J/HPIHBtn1AuIdIG/rU/xS0v0rSX3rh0Va4Jzicaz9mxeQ0o/O9j3rWoBsF17DVa+sT6vNXhA==
+"@unleash/client-specification@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@unleash/client-specification/-/client-specification-4.2.1.tgz#32e0070ce8a1edd1602c886ab3086b61750af31a"
+  integrity sha512-wXDWAPkbClA9TNbBPqkqeF8ub8/WJA+/CVeBsxCBF1q6Cdt5GRXCylmBFF2iPx5QhYzuqfuEC7+I45O53/xkWA==
 
 acorn-jsx@^5.3.1:
   version "5.3.2"


### PR DESCRIPTION
We saw some inconsistent handling of missing context fields on in the SDK together with `IN` and `NOT_IN` operator. 

E.g. When the user has a `NOT_IN` and does not provide any context field the SDK should return true, while the node SDK is currently always returning false in that case. 
