### PR TITLE
fix: string operator needs to guard against non-string values

### DIFF
--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -70,6 +70,10 @@ const StringOperator = (constraint: Constraint, context: Context) => {
     contextValue = contextValue?.toLocaleLowerCase();
   }
 
+  if(typeof contextValue !== 'string') {
+    return false;
+  }
+
   if (operator === Operator.STR_STARTS_WITH) {
     return values.some((val) => contextValue?.startsWith(val));
   }

--- a/test/strategy/strategy-test.js
+++ b/test/strategy/strategy-test.js
@@ -176,7 +176,7 @@ test('should not be enabled when email endsWith, caring about case', (t) => {
   t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
-test('should not be enabled when email endsWith, missing field', (t) => {
+test('should not be enabled when companyId endsWith, field of incorrect type', (t) => {
   const strategy = new Strategy('test', true);
   const params = {};
   const constraints = [
@@ -189,6 +189,26 @@ test('should not be enabled when email endsWith, missing field', (t) => {
     }
   };
   t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+});
+
+test('should be enabled when companyId endsWith, field of incorrect type, inverted', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    {
+      contextName: 'companyId',
+      operator: 'STR_ENDS_WITH',
+      values: ['@getunleash.ai'],
+      inverted: true
+    },
+  ];
+  const context = {
+    environment: 'dev',
+    properties: {
+      companyId: 123
+    }
+  };
+  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
 test('should be enabled when email NOT endsWith (inverted)', (t) => {

--- a/test/strategy/strategy-test.js
+++ b/test/strategy/strategy-test.js
@@ -176,6 +176,21 @@ test('should not be enabled when email endsWith, caring about case', (t) => {
   t.false(strategy.isEnabledWithConstraints(params, context, constraints));
 });
 
+test('should not be enabled when email endsWith, missing field', (t) => {
+  const strategy = new Strategy('test', true);
+  const params = {};
+  const constraints = [
+    { contextName: 'companyId', operator: 'STR_ENDS_WITH', values: ['@getunleash.ai'] },
+  ];
+  const context = {
+    environment: 'dev',
+    properties: {
+      companyId: 123
+    }
+  };
+  t.false(strategy.isEnabledWithConstraints(params, context, constraints));
+});
+
 test('should be enabled when email NOT endsWith (inverted)', (t) => {
   const strategy = new Strategy('test', true);
   const params = {};


### PR DESCRIPTION
If the user passes a number instead of a string on a context field where we use the string operator the node SDK will currently crash. 

This PR adds a check that the context field is actually a string. 