### PR TITLE
Emit "unchanged" event

### DIFF
--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -136,6 +136,8 @@ export class Unleash extends EventEmitter {
 
     this.repository.on(UnleashEvents.Warn, (msg) => this.emit(UnleashEvents.Warn, msg));
 
+    this.repository.on(UnleashEvents.Unchanged, (msg) => this.emit(UnleashEvents.Unchanged, msg));
+
     this.repository.on(UnleashEvents.Changed, (data) => {
       this.emit(UnleashEvents.Changed, data);
 

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -6,7 +6,7 @@ import mkdirp from 'mkdirp';
 import sinon from 'sinon';
 import FakeRepo from './fake_repo';
 
-import { Strategy, Unleash } from '../lib/unleash';
+import { Strategy, Unleash, UnleashEvents } from '../lib/unleash';
 
 class EnvironmentStrategy extends Strategy {
   constructor() {
@@ -141,20 +141,20 @@ test('should re-emit events from repository and metrics', (t) => {
   });
 
   t.plan(7);
-  instance.on('warn', (e) => t.truthy(e));
-  instance.on('sent', (e) => t.truthy(e));
-  instance.on('registered', (e) => t.truthy(e));
-  instance.on('count', (e) => t.truthy(e));
-  instance.on('unchanged', (e) => t.truthy(e));
-  instance.on('changed', (e) => t.truthy(e));
+  instance.on(UnleashEvents.Warn, (e) => t.truthy(e));
+  instance.on(UnleashEvents.Sent, (e) => t.truthy(e));
+  instance.on(UnleashEvents.Registered, (e) => t.truthy(e));
+  instance.on(UnleashEvents.Count, (e) => t.truthy(e));
+  instance.on(UnleashEvents.Unchanged, (e) => t.truthy(e));
+  instance.on(UnleashEvents.Changed, (e) => t.truthy(e));
 
-  instance.repository.emit('warn', true);
-  instance.repository.emit('changed', true);
-  instance.repository.emit('unchanged', true);
-  instance.metrics.emit('warn', true);
-  instance.metrics.emit('sent', true);
-  instance.metrics.emit('registered', true);
-  instance.metrics.emit('count', true);
+  instance.repository.emit(UnleashEvents.Warn, true);
+  instance.repository.emit(UnleashEvents.Changed, true);
+  instance.repository.emit(UnleashEvents.Unchanged, true);
+  instance.metrics.emit(UnleashEvents.Warn, true);
+  instance.metrics.emit(UnleashEvents.Sent, true);
+  instance.metrics.emit(UnleashEvents.Registered, true);
+  instance.metrics.emit(UnleashEvents.Count, true);
 
   instance.destroy();
 });

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -140,13 +140,17 @@ test('should re-emit events from repository and metrics', (t) => {
     url,
   });
 
-  t.plan(5);
+  t.plan(7);
   instance.on('warn', (e) => t.truthy(e));
   instance.on('sent', (e) => t.truthy(e));
   instance.on('registered', (e) => t.truthy(e));
   instance.on('count', (e) => t.truthy(e));
+  instance.on('unchanged', (e) => t.truthy(e));
+  instance.on('changed', (e) => t.truthy(e));
 
   instance.repository.emit('warn', true);
+  instance.repository.emit('changed', true);
+  instance.repository.emit('unchanged', true);
   instance.metrics.emit('warn', true);
   instance.metrics.emit('sent', true);
   instance.metrics.emit('registered', true);


### PR DESCRIPTION
## About the changes
`Unleash` was not actually re-emitting the "unchanged" event from the toggle repository as expected based on the readme.
Add an event handler on `repository` to forward this event to the consumers.