### PR TITLE
feat: add metrics jitter support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,8 +49,12 @@ export function generateInstanceId(instanceId?: string): string {
   return `${prefix}-${hostname()}`;
 }
 
-
 export function generateHashOfObject(o: Object): string {
   const oAsString = JSON.stringify(o);
   return murmurHash3.x86.hash128(oAsString);
+}
+
+export function getAppliedJitter(jitter: number): number {
+  const appliedJitter = Math.random() * jitter;
+  return Math.random() < 0.5 ? -appliedJitter : appliedJitter;
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,6 +6,7 @@ import { sdkVersion } from './details.json';
 import { HttpOptions } from './http-options';
 import { suffixSlash } from './url-utils';
 import { UnleashEvents } from './events';
+import { getAppliedJitter } from './helpers';
 
 export interface MetricsOptions {
   appName: string;
@@ -93,8 +94,7 @@ export default class Metrics extends EventEmitter {
   }
 
   private getAppliedJitter() {
-    const jitter = Math.random() * this.metricsJitter;
-    return Math.random() < 0.5 ? -jitter : jitter;
+    return getAppliedJitter(this.metricsJitter);
   }
 
   private startTimer() {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -30,6 +30,7 @@ export interface UnleashConfig {
   refreshInterval?: number;
   projectName?: string;
   metricsInterval?: number;
+  metricsJitter?: number;
   namePrefix?: string;
   disableMetrics?: boolean;
   backupPath?: string;
@@ -79,6 +80,7 @@ export class Unleash extends EventEmitter {
     url,
     refreshInterval = 15 * 1000,
     metricsInterval = 60 * 1000,
+    metricsJitter = 0,
     disableMetrics = false,
     backupPath = BACKUP_PATH,
     strategies = [],
@@ -189,6 +191,7 @@ export class Unleash extends EventEmitter {
       instanceId: unleashInstanceId,
       strategies: supportedStrategies.map((strategy: Strategy) => strategy.name),
       metricsInterval,
+      metricsJitter,
       url: unleashUrl,
       headers: customHeaders,
       customHeadersFunction,

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,8 @@
+import test from 'ava';
+
+import { getAppliedJitter } from '../lib/helpers';
+
+test('jitter should be within bounds', (t) => {
+    const jitter = getAppliedJitter(10000);
+    t.true(jitter <= 10000 && jitter >= -10000)
+});


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

This PR adds support for `metricsJitter` which can be useful to evenly distribute the load on server for sending metrics.

This is related to https://github.com/Unleash/unleash-proxy/issues/108, and after we applied the jitter to the [python client](https://github.com/Unleash/unleash-client-python/blob/main/UnleashClient/__init__.py#L37) (which already supports this), we saw load on our server even out.



<img width="467" alt="Screenshot 2023-01-11 at 10 34 25" src="https://user-images.githubusercontent.com/8524109/212619699-c8689cfe-cc3b-4092-b695-50339a4a3d22.png">
