### PR TITLE
Feat/flush metrics

### DIFF
--- a/examples/simple_usage_sync.js
+++ b/examples/simple_usage_sync.js
@@ -1,0 +1,28 @@
+const { initialize } = require('../lib');
+
+const url = 'http://localhost:4242/api/';
+const apiToken = '*:development.e45bc2844592103afb60cfa90f039c487395e88d7751cf59c2a99329';
+const toggleName = 'demo6';
+const unleashContext = { };
+
+const unleash = initialize({
+  appName: 'my-application',
+  url,
+  customHeaders: {
+    Authorization: apiToken,
+  }
+});
+
+unleash.on('error', console.warn);
+unleash.on('warn', console.warn);
+unleash.on('ready', () => console.log('ready!'));
+
+console.log(`Fetching toggles from: ${url}`);
+
+unleash.on('synchronized', () => {
+  for(let i=0; i< 100; i++) {
+    const v = unleash.isEnabled(toggleName, unleashContext);
+    console.log(v);
+  }
+  unleash.destroyWithFlush();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,3 +71,11 @@ export function count(toggleName: string, enabled: boolean) {
 export function countVariant(toggleName: string, variantName: string) {
   return instance && instance.countVariant(toggleName, variantName);
 }
+
+export async function flushMetrics(): Promise<void> {
+  return instance && instance.flushMetrics();
+}
+
+export async function destroyWithFlush(): Promise<void> {
+  return instance && instance.destroyWithFlush();
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -170,14 +170,14 @@ export default class Metrics extends EventEmitter {
     return true;
   }
 
-  async sendMetrics(): Promise<boolean> {
+  async sendMetrics(): Promise<void> {
     if (this.disabled) {
-      return false;
+      return;
     }
     if (this.bucketIsEmpty()) {
       this.resetBucket();
       this.startTimer();
-      return true;
+      return;
     }
     const url = resolveUrl(suffixSlash(this.url), './client/metrics');
     const payload = this.createMetricsData();
@@ -210,7 +210,6 @@ export default class Metrics extends EventEmitter {
       this.emit(UnleashEvents.Warn, err);
       this.startTimer();
     }
-    return true;
   }
 
   assertBucket(name: string): void {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -346,4 +346,13 @@ export class Unleash extends EventEmitter {
   countVariant(toggleName: string, variantName: string) {
     this.metrics.countVariant(toggleName, variantName);
   }
+
+  flushMetrics(): Promise<void> {
+    return this.metrics.sendMetrics();
+  }
+
+  async destroyWithFlush(): Promise<void> {
+    await this.flushMetrics()
+    this.destroy();
+  }
 };

--- a/test/metrics.network.test.js
+++ b/test/metrics.network.test.js
@@ -23,7 +23,7 @@ test.cb('registerInstance should emit error when request error', (t) => {
 });
 
 test.cb('sendMetrics should emit error when request error', (t) => {
-  t.plan(2);
+  t.plan(1);
   const url = 'http://metrics2.app/';
 
   const metrics = new Metrics({
@@ -35,8 +35,7 @@ test.cb('sendMetrics should emit error when request error', (t) => {
 
   metrics.count('x', true);
 
-  metrics.sendMetrics().then((result) => {
-    t.true(result);
+  metrics.sendMetrics().then(() => {
     t.end();
   });
 });

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -298,8 +298,7 @@ test.cb('sendMetrics should not send empty buckets', (t) => {
   });
   metrics.start();
 
-  metrics.sendMetrics().then((result) => {
-    t.true(result);
+  metrics.sendMetrics().then(() => {
 
     setTimeout(() => {
       t.false(metEP.isDone());


### PR DESCRIPTION
Adds a flush metrics method, making it easier to gracefully shutdown the SDK and capture the last bucket of metrics. 

This one looks a bit messy because it was built directly on top of #414