### PR TITLE
fix: flexible-rollout random stickiness is not random enough

### DIFF
--- a/src/strategy/flexible-rollout-strategy.ts
+++ b/src/strategy/flexible-rollout-strategy.ts
@@ -9,12 +9,12 @@ const STICKINESS = {
 };
 
 export default class FlexibleRolloutStrategy extends Strategy {
-  private randomGenerator: Function = () => `${Math.round(Math.random() * 100) + 1}`;
+  private randomGenerator: Function = () => `${Math.round(Math.random() * 10000) + 1}`;
 
-  constructor(radnomGenerator?: Function) {
+  constructor(randomGenerator?: Function) {
     super('flexibleRollout');
-    if (radnomGenerator) {
-      this.randomGenerator = radnomGenerator;
+    if (randomGenerator) {
+      this.randomGenerator = randomGenerator;
     }
   }
 


### PR DESCRIPTION
It's easy to get skew when we only pick numbers between 0 and 100.
