### PR TITLE
Allow SDK to startup when backup data is corrupt

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -164,7 +164,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
         this.setReady();
       }
     } catch (err) {
-      this.emit(UnleashEvents.Error, err);
+      this.emit(UnleashEvents.Warn, err);
     }
   }
 

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -3,6 +3,8 @@ import nock from 'nock';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import mkdirp from 'mkdirp';
+import { writeFileSync } from 'fs';
+import { Unleash } from '../lib/unleash';
 
 import { initialize, isEnabled, destroy } from '../lib/index';
 
@@ -24,9 +26,7 @@ let counter = 0;
 function mockNetwork(toggles = defaultToggles) {
   counter += 1;
   const url = `http://unleash-${counter}.app`;
-  nock(url)
-    .get('/client/features')
-    .reply(200, { features: toggles });
+  nock(url).get('/client/features').reply(200, { features: toggles });
   return url;
 }
 
@@ -42,6 +42,33 @@ test('should be able to call api', (t) => {
   });
   t.true(isEnabled('unknown') === false);
   destroy();
+});
+
+test.cb('should load if backup file is corrupted', (t) => {
+  const url = mockNetwork();
+  const backupPath = join(tmpdir());
+  const backupFile = join(backupPath, `/unleash-backup-with-corrupted-JSON.json`);
+  writeFileSync(backupFile, '{broken-json');
+
+  const instance = new Unleash({
+    appName: 'with-corrupted-JSON',
+    metricsInterval: 0,
+    url,
+    backupPath: backupPath,
+    refreshInterval: 0,
+  });
+
+  instance
+    .on('error', (err) => {
+      destroy();
+      throw err;
+    })
+    .on('warn', (err) => {
+      if (err?.message?.includes('Unleash storage failed parsing file')) {
+        destroy();
+        t.end();
+      }
+    });
 });
 
 test.cb('should be able to call isEnabled eventually', (t) => {
@@ -69,4 +96,4 @@ test.cb('should return fallbackValue if init was not called', (t) => {
   t.true(isEnabled('feature', {}, false) === false);
   t.true(isEnabled('feature', {}, true) === true);
   t.end();
-})
+});

--- a/test/repository.test.js
+++ b/test/repository.test.js
@@ -680,7 +680,7 @@ test('bootstrap should not override load backup-file', async t => {
     .persist()
     .get('/client/features')
     .reply(408);
-  
+
   nock(url)
     .persist()
     .get('/bootstrap')


### PR DESCRIPTION
This moves the error that's emitted when the SDK encounters a corrupted JSON backup file to rather be a warning. The backup file shouldn't block the startup sequence, even when it's broken, since the next API hit will cause the SDK to rewrite the file with clean data