### PR TITLE
fix: use base node12 tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "devDependencies": {
     "@ava/babel": "2.0.0",
+    "@tsconfig/node12": "^1.0.11",
     "@types/ip": "1.1.0",
     "@types/make-fetch-happen": "10.0.1",
     "@types/murmurhash3js": "3.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,14 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "lib": ["es5", "es6"],
-    "target": "es5",
-    "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true,
-    "strict": true,
-    "moduleResolution": "node",
-    "downlevelIteration": true
+    "esModuleInterop": false,
+    "skipLibCheck": false
   },
   "exclude": ["examples/", "lib/", "node_modules/"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node12@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
 "@types/ip@1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

The current transpile target transpiles a bunch of code that's not needed, such as `async` functions and `class`es - both of which are heavily used in this code base.

You target a minimum of node 12, so that's the config I've used: https://github.com/Unleash/unleash-client-node/blob/18ee8ef5a397b8d1615dccd1bbc93edea85bfa0c/.github/workflows/master.yaml#L13

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

`tsconfig.json`


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

This is the full diff of the transpiled code: https://gist.github.com/SimenB/6608476192348cc2676dd75e6d76cdf8