### PR TITLE
chore: use builtin caching of `actions/setup-node`

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -19,8 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
-      - name: Setup yarn cache
-        uses: c-hive/gha-yarn-cache@v2
+          cache: yarn
       - name: Yarn
         run: yarn
       - name: Test

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
-      - name: Setup yarn cache
-        uses: c-hive/gha-yarn-cache@v2
+          cache: yarn
       - name: Yarn
         run: yarn
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'
+        cache: yarn
     - run: |
         yarn install --frozen-lockfile
     - run: |


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

The current action is spewing out deprecation warnings.

<img width="1940" alt="image" src="https://user-images.githubusercontent.com/1404810/219646926-de4959a7-9663-418b-bd69-270784c069bc.png">

`actions/setup-node` has had builtin `node_modules` caching for a long time at this point, so just using that seems best

(coveralls is https://github.com/coverallsapp/github-action/issues/132)

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
