### PR TITLE
Fix: Add check on impressionData

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -56,13 +56,16 @@ export default class UnleashClient extends EventEmitter {
   isEnabled(name: string, context: Context, fallback: Function): boolean {
     const feature = this.repository.getToggle(name);
     const enabled = this.isFeatureEnabled(feature, context, fallback);
-    if(feature?.impressionData) {
-      this.emit(UnleashEvents.Impression, createImpressionEvent({
-        featureName: name,
-        context,
-        enabled,
-        eventType: 'isEnabled',
-      }));
+    if (feature?.impressionData) {
+      this.emit(
+        UnleashEvents.Impression,
+        createImpressionEvent({
+          featureName: name,
+          context,
+          enabled,
+          eventType: 'isEnabled',
+        }),
+      );
     }
     return enabled;
   }
@@ -132,14 +135,17 @@ export default class UnleashClient extends EventEmitter {
   getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
     const feature = this.repository.getToggle(name);
     const variant = this.resolveVariant(feature, context, true, fallbackVariant);
-    if(feature?.impressionData){
-      this.emit(UnleashEvents.Impression, createImpressionEvent({
-        featureName: name,
-        context,
-        enabled: variant.enabled,
-        eventType: 'getVariant',
-        variant: variant.name,
-      }));
+    if (feature?.impressionData) {
+      this.emit(
+        UnleashEvents.Impression,
+        createImpressionEvent({
+          featureName: name,
+          context,
+          enabled: variant.enabled,
+          eventType: 'getVariant',
+          variant: variant.name,
+        }),
+      );
     }
     return variant;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,7 +56,7 @@ export default class UnleashClient extends EventEmitter {
   isEnabled(name: string, context: Context, fallback: Function): boolean {
     const feature = this.repository.getToggle(name);
     const enabled = this.isFeatureEnabled(feature, context, fallback);
-    if(feature.impressionData) {
+    if(feature?.impressionData===true) {
       this.emit(UnleashEvents.Impression, createImpressionEvent({
         featureName: name,
         context,
@@ -132,7 +132,7 @@ export default class UnleashClient extends EventEmitter {
   getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
     const feature = this.repository.getToggle(name);
     const variant = this.resolveVariant(feature, context, true, fallbackVariant);
-    if(feature.impressionData){
+    if(feature?.impressionData===true){
       this.emit(UnleashEvents.Impression, createImpressionEvent({
         featureName: name,
         context,

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,7 +56,7 @@ export default class UnleashClient extends EventEmitter {
   isEnabled(name: string, context: Context, fallback: Function): boolean {
     const feature = this.repository.getToggle(name);
     const enabled = this.isFeatureEnabled(feature, context, fallback);
-    if(feature?.impressionData===true) {
+    if(feature?.impressionData) {
       this.emit(UnleashEvents.Impression, createImpressionEvent({
         featureName: name,
         context,
@@ -132,7 +132,7 @@ export default class UnleashClient extends EventEmitter {
   getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
     const feature = this.repository.getToggle(name);
     const variant = this.resolveVariant(feature, context, true, fallbackVariant);
-    if(feature?.impressionData===true){
+    if(feature?.impressionData){
       this.emit(UnleashEvents.Impression, createImpressionEvent({
         featureName: name,
         context,

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,12 +56,14 @@ export default class UnleashClient extends EventEmitter {
   isEnabled(name: string, context: Context, fallback: Function): boolean {
     const feature = this.repository.getToggle(name);
     const enabled = this.isFeatureEnabled(feature, context, fallback);
-    this.emit(UnleashEvents.Impression, createImpressionEvent({
-      featureName: name,
-      context,
-      enabled,
-      eventType: 'isEnabled'
-    }));
+    if(feature.impressionData) {
+      this.emit(UnleashEvents.Impression, createImpressionEvent({
+        featureName: name,
+        context,
+        enabled,
+        eventType: 'isEnabled',
+      }));
+    }
     return enabled;
   }
 
@@ -128,14 +130,17 @@ export default class UnleashClient extends EventEmitter {
   }
 
   getVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
-    const variant = this.resolveVariant(name, context, true, fallbackVariant);
-    this.emit(UnleashEvents.Impression, createImpressionEvent({
-      featureName: name,
-      context,
-      enabled: variant.enabled,
-      eventType: 'getVariant',
-      variant: variant.name,
-    }));
+    const feature = this.repository.getToggle(name);
+    const variant = this.resolveVariant(feature, context, true, fallbackVariant);
+    if(feature.impressionData){
+      this.emit(UnleashEvents.Impression, createImpressionEvent({
+        featureName: name,
+        context,
+        enabled: variant.enabled,
+        eventType: 'getVariant',
+        variant: variant.name,
+      }));
+    }
     return variant;
   }
 
@@ -143,17 +148,17 @@ export default class UnleashClient extends EventEmitter {
   // state gets checked twice when resolving a variant with random stickiness and
   // gradual rollout. This is not intended for general use, prefer getVariant instead
   forceGetVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
-    return this.resolveVariant(name, context, false, fallbackVariant);
+    const feature = this.repository.getToggle(name);
+    return this.resolveVariant(feature, context, false, fallbackVariant);
   }
 
   private resolveVariant(
-    name: string,
+    feature: FeatureInterface,
     context: Context,
     checkToggle: boolean,
     fallbackVariant?: Variant,
   ): Variant {
     const fallback = fallbackVariant || getDefaultVariant();
-    const feature = this.repository.getToggle(name);
     if (
       typeof feature === 'undefined' ||
       !feature.variants ||

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -6,7 +6,7 @@ import CustomStrategy from './true_custom_strategy';
 import CustomFalseStrategy from './false_custom_strategy';
 import { UnleashEvents } from '../lib/events';
 
-function buildToggle(name, active, strategies, variants = [], impressionData= false) {
+function buildToggle(name, active, strategies, variants = [], impressionData = false) {
   return {
     name,
     enabled: active,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -281,25 +281,32 @@ test('should not trigger events if impressionData is false', (t) => {
 });
 
 test('should trigger events on isEnabled if impressionData is true', (t) => {
+  let called = false
   const repo = {
     getToggle() {
       return buildToggle('feature-x', false, undefined, undefined, true);
     },
   };
   const client = new Client(repo, []);
-  client.on(UnleashEvents.Impression, ()=> t.pass());
-
+  client.on(UnleashEvents.Impression, ()=> {
+    called=true;
+  });
   client.isEnabled('feature-x', {}, () => false);
+  t.true(called)
+
 });
 
 test('should trigger events on getVariant if impressionData is true', (t) => {
+  let called = false
   const repo = {
     getToggle() {
       return buildToggle('feature-x', false, undefined, undefined, true);
     },
   };
   const client = new Client(repo, []);
-  client.on(UnleashEvents.Impression, ()=> t.pass());
-
+  client.on(UnleashEvents.Impression, ()=> {
+    called=true;
+  });
   client.getVariant('feature-x', {}, );
+  t.true(called)
 });

--- a/test/unleash.test.js
+++ b/test/unleash.test.js
@@ -712,6 +712,7 @@ test('should use provided bootstrap data', (t) =>
             name: 'toggle-impressions',
             enabled: true,
             strategies: [{ name: 'default' }],
+            impressionData: true,
             variants: [
               {
                 name: 'blue',
@@ -733,7 +734,7 @@ test('should use provided bootstrap data', (t) =>
           },
         ],
       });
-  
+
     const unleash = new Unleash({
       appName: 'foo-variants-3',
       disableMetrics: true,
@@ -743,7 +744,7 @@ test('should use provided bootstrap data', (t) =>
     });
 
     const context = { userId: '123', properties: {tenantId: 't12'} };
-  
+
     return new Promise((resolve) => {
       unleash.on('impression', (evt) => {
         t.is(evt.featureName, 'toggle-impressions');
@@ -771,6 +772,7 @@ test('should use provided bootstrap data', (t) =>
             name: 'toggle-impressions',
             enabled: true,
             strategies: [{ name: 'default' }],
+            impressionData: true,
             variants: [
               {
                 name: 'blue',
@@ -792,7 +794,7 @@ test('should use provided bootstrap data', (t) =>
           },
         ],
       });
-  
+
     const unleash = new Unleash({
       appName: 'foo-variants-4',
       disableMetrics: true,
@@ -802,7 +804,7 @@ test('should use provided bootstrap data', (t) =>
     });
 
     const context = { userId: '123', properties: {tenantId: 't12'} };
-  
+
     return new Promise((resolve) => {
       unleash.on('impression', (evt) => {
         t.is(evt.featureName, 'toggle-impressions');
@@ -841,7 +843,7 @@ test('should use provided bootstrap data', (t) =>
     });
 
     t.is(i1, i2);
-    
+
     i1.destroy();
     i2.destroy();
   });
@@ -865,14 +867,14 @@ test('should use provided bootstrap data', (t) =>
       skipInstanceCountWarning: true,
       url: baseUrl,
     }));
-    
+
     i1.destroy();
   });
 
   test('should allow custom repository', (t) =>
   new Promise((resolve) => {
     const url = getUrl();
-    
+
     const instance = Unleash.getInstance({
       appName: 'foo',
       disableMetrics: true,


### PR DESCRIPTION
## About the changes

[Impression Data](https://docs.getunleash.io/reference/impression-data) is an opt-in feature. However, the previous implementation triggered events regardless of the status of the impressionData field. This fix adds a check on the status of the impressionData field on FeatureInterface before triggering the event.

### Important files

src/client.ts


## Discussion points

This fix addresses that issue however is more invasive than I would prefer. The change required making an update to the interface of the resolve variant function.