### PR TITLE
fix: always resolve startUnleash promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export function initialize(options: UnleashConfig): Unleash {
 
 export async function startUnleash(options: UnleashConfig): Promise<Unleash> {
   const unleash = initialize(options);
-  await once(unleash, 'synchronized');
+  if (!unleash.isSynchronized()) {
+    await once(unleash, 'synchronized');
+  }
   return unleash;
 }
 

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -238,6 +238,10 @@ export class Unleash extends EventEmitter {
     return unleashUrl;
   }
 
+  isSynchronized() {
+    return this.synchronized;
+  }
+
   async start(): Promise<void> {
     await Promise.all([this.repository.start(), this.metrics.start()]);
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,12 +66,25 @@ test('should not return feature-toggle definition if there is no instance', t =>
   t.is(getFeatureToggleDefinition(), undefined);
 });
 
-test('should start unleash with promise', async (t) => {
+test.serial('should start unleash with promise', async (t) => {
   const url = getUrl();
   nockFeatures(url);
   nockMetrics(url);
   nockRegister(url);
   const unleash = await startUnleash({ appName: 'my-app-name', url });
   t.truthy(unleash);
+  destroy();
+});
+
+test.serial('should start unleash with promise multiple times', async (t) => {
+  const url = getUrl();
+  nockFeatures(url);
+  nockMetrics(url);
+  nockRegister(url);
+  const config = { appName: 'my-app-name', url };
+  const unleash1 = await startUnleash(config);
+  t.truthy(unleash1);
+  const unleash2 = await startUnleash(config);
+  t.truthy(unleash2);
   destroy();
 });


### PR DESCRIPTION
## About the changes

`startUnleash` should wait for the `synchronized` event only when the Unleash instance isn't already synchronized.
Without the changes introduced by this PR, any subsequent invocation of `startUnleash` will produce an unresolved promise.

Closes #441 
