### PR TITLE
fix: specify all payload types and export them

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { once } from 'events';
 import { Unleash } from './unleash';
-import { Variant, getDefaultVariant } from './variant';
+import { Variant, getDefaultVariant, PayloadType } from './variant';
 import { Context } from './context';
 import { TagFilter } from './tags';
 import { UnleashEvents } from './events';
@@ -10,11 +10,10 @@ import { UnleashConfig } from './unleash-config';
 
 // exports
 export { Strategy } from './strategy/index';
-export { Context, Variant, Unleash, TagFilter, InMemStorageProvider, UnleashEvents };
+export { Context, Variant, PayloadType, Unleash, TagFilter, InMemStorageProvider, UnleashEvents };
 export type { ClientFeaturesResponse, UnleashConfig };
 
 let instance: undefined | Unleash;
-
 
 export function initialize(options: UnleashConfig): Unleash {
   instance = Unleash.getInstance(options);
@@ -35,7 +34,7 @@ export function isEnabled(name: string, context: Context = {}, fallbackValue?: b
 }
 
 export function destroy() {
-  if (instance ) {
+  if (instance) {
     instance.destroy();
   }
   instance = undefined;

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -4,8 +4,10 @@ import { FeatureInterface } from './feature';
 import normalizedValue from './strategy/util';
 import { resolveContextValue } from './helpers';
 
-enum PayloadType {
+export enum PayloadType {
   STRING = 'string',
+  JSON = 'json',
+  CSV = 'csv',
 }
 
 interface Override {


### PR DESCRIPTION
Is there any reason why we're not specifying all variant payload types and exporting them?

My use case is leveraging this in [unleash](https://github.com/unleash/unleash) so I can have proper types and type-checking.

![image](https://github.com/Unleash/unleash-client-node/assets/14320932/dfa3c9c3-236a-431a-962d-7fc71c949eed)
