### PR TITLE
3.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-client",
-  "version": "3.19.1",
+  "version": "3.20.0",
   "description": "Unleash Client for Node",
   "license": "Apache-2.0",
   "main": "./lib/index.js",

--- a/src/details.json
+++ b/src/details.json
@@ -1,1 +1,1 @@
-{"name":"unleash-client-node","version":"3.19.1","sdkVersion":"unleash-client-node:3.19.1"}
+{ "name": "unleash-client-node", "version": "3.20.0", "sdkVersion": "unleash-client-node:3.20.0" }


### PR DESCRIPTION
As per https://github.com/Unleash/unleash-client-node/pull/453#issuecomment-1549811041
Bumps to `3.20.0` to cut a minor release.