### PR TITLE
fix: getToggle by name may not find the toggle

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -70,7 +70,11 @@ export default class UnleashClient extends EventEmitter {
     return enabled;
   }
 
-  isFeatureEnabled(feature: FeatureInterface, context: Context, fallback: Function): boolean {
+  isFeatureEnabled(
+    feature: FeatureInterface | undefined,
+    context: Context,
+    fallback: Function,
+  ): boolean {
     if (!feature) {
       return fallback();
     }
@@ -159,7 +163,7 @@ export default class UnleashClient extends EventEmitter {
   }
 
   private resolveVariant(
-    feature: FeatureInterface,
+    feature: FeatureInterface | undefined,
     context: Context,
     checkToggle: boolean,
     fallbackVariant?: Variant,

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -13,7 +13,7 @@ import { Segment } from '../strategy/strategy';
 const SUPPORTED_SPEC_VERSION = '4.2.0';
 
 export interface RepositoryInterface extends EventEmitter {
-  getToggle(name: string): FeatureInterface;
+  getToggle(name: string): FeatureInterface | undefined;
   getToggles(): FeatureInterface[];
   getSegment(id: number): Segment | undefined;
   stop(): void;
@@ -117,7 +117,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     this.segments = new Map();
   }
 
-  timedFetch(interval: number ) {
+  timedFetch(interval: number) {
     if (interval > 0) {
       this.timer = setTimeout(() => this.fetch(), interval);
       if (process.env.NODE_ENV !== 'test' && typeof this.timer.unref === 'function') {
@@ -290,7 +290,7 @@ Message: ${err.message}`,
       }
     } catch (err) {
       const e = err as { code: string };
-      if(e.code === 'ECONNRESET') {
+      if (e.code === 'ECONNRESET') {
         nextFetch = Math.max(Math.floor(this.refreshInterval / 2), 1000);
         this.emit(UnleashEvents.Warn, `Socket keep alive error, retrying in ${nextFetch}ms`);
       } else {
@@ -317,7 +317,7 @@ Message: ${err.message}`,
     return this.segments.get(segmentId);
   }
 
-  getToggle(name: string): FeatureInterface {
+  getToggle(name: string): FeatureInterface | undefined {
     return this.data[name];
   }
 

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -8,9 +8,12 @@ import { Strategy, defaultStrategies } from './strategy';
 
 import { FeatureInterface } from './feature';
 import { Variant, getDefaultVariant } from './variant';
-import { 
+import {
   FallbackFunction,
-  createFallbackFunction, generateInstanceId, generateHashOfConfig } from './helpers';
+  createFallbackFunction,
+  generateInstanceId,
+  generateHashOfConfig,
+} from './helpers';
 import { resolveBootstrapProvider } from './repository/bootstrap-provider';
 import { ImpressionEvent, UnleashEvents } from './events';
 import { UnleashConfig } from './unleash-config';
@@ -72,21 +75,19 @@ export class Unleash extends EventEmitter {
     super();
 
     Unleash.instanceCount++;
-    
 
     this.on(UnleashEvents.Error, (error) => {
       // Only if there does not exist other listeners for this event.
-      if(this.listenerCount(UnleashEvents.Error) === 1)  {
-        console.error(error);  
+      if (this.listenerCount(UnleashEvents.Error) === 1) {
+        console.error(error);
       }
-      
     });
 
-    if(!skipInstanceCountWarning && Unleash.instanceCount > 10) {
+    if (!skipInstanceCountWarning && Unleash.instanceCount > 10) {
       process.nextTick(() => {
         const error = new Error('The unleash SDK has been initialized more than 10 times');
         this.emit(UnleashEvents.Error, error);
-      })
+      });
     }
 
     if (!url) {
@@ -155,7 +156,8 @@ export class Unleash extends EventEmitter {
     this.client = new Client(this.repository, supportedStrategies);
     this.client.on(UnleashEvents.Error, (err) => this.emit(UnleashEvents.Error, err));
     this.client.on(UnleashEvents.Impression, (e: ImpressionEvent) =>
-      this.emit(UnleashEvents.Impression, e));
+      this.emit(UnleashEvents.Impression, e),
+    );
 
     this.metrics = new Metrics({
       disableMetrics,
@@ -193,9 +195,9 @@ export class Unleash extends EventEmitter {
   }
 
   /**
-   * Will only give you an instance the first time you call the method, 
-   * and then return the same instance. 
-   * @param config The Unleash Config. 
+   * Will only give you an instance the first time you call the method,
+   * and then return the same instance.
+   * @param config The Unleash Config.
    * @returns the Unleash instance
    */
   static getInstance(config: UnleashConfig) {
@@ -204,15 +206,15 @@ export class Unleash extends EventEmitter {
       // Remove complex objects
       repository: undefined,
       customHeadersFunction: undefined,
-      storageProvider: undefined
+      storageProvider: undefined,
     };
     const configSignature = generateHashOfConfig(cleanConfig);
-    if(Unleash.instance) {
-      if(configSignature !== Unleash.configSignature) {
+    if (Unleash.instance) {
+      if (configSignature !== Unleash.configSignature) {
         throw new Error('You already have an Unleash instance with a different configuration.');
       }
       return Unleash.instance;
-    } 
+    }
     const instance = new Unleash(config);
     Unleash.instance = instance;
     Unleash.configSignature = configSignature;
@@ -314,7 +316,7 @@ export class Unleash extends EventEmitter {
     return result;
   }
 
-  getFeatureToggleDefinition(toggleName: string): FeatureInterface {
+  getFeatureToggleDefinition(toggleName: string): FeatureInterface | undefined {
     return this.repository.getToggle(toggleName);
   }
 
@@ -335,7 +337,7 @@ export class Unleash extends EventEmitter {
   }
 
   async destroyWithFlush(): Promise<void> {
-    await this.flushMetrics()
+    await this.flushMetrics();
     this.destroy();
   }
-};
+}


### PR DESCRIPTION
## About the changes
Node SDK interface should notify that getting a toggle by name can return undefined if the toggle does not exist:
https://github.com/Unleash/unleash/blob/d298b04cb2864b4853ca456e402714c98adaf932/src/lib/proxy/proxy-repository.ts#L75-L77
