### PR TITLE
fix: force get variant is back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-client",
-  "version": "4.1.0-beta.2",
+  "version": "4.1.0-beta.3",
   "description": "Unleash Client for Node",
   "license": "Apache-2.0",
   "main": "./lib/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -172,7 +172,7 @@ export default class UnleashClient extends EventEmitter {
   // gradual rollout. This is not intended for general use, prefer getVariant instead
   forceGetVariant(name: string, context: Context, fallbackVariant?: Variant): Variant {
     const feature = this.repository.getToggle(name);
-    return this.resolveVariant(feature, context, false, fallbackVariant);
+    return this.resolveVariant(feature, context, true, fallbackVariant);
   }
 
   private resolveVariant(


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

forceGetVariant should still be used in proxy/frontend API because it's not emitting impression events. The only difference is that it now evaluates the toggle under the hood (for the strategy variants support) because the experiments confirmed it's not skewing % distribution. I'm afraid that if we switch proxy and frontend SDK to getVariant the impression event will be emitted twice from the client SDK AND frontend API/proxy

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
