### PR TITLE
refactor: strategy variants inside strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-client",
-  "version": "4.1.0-beta.3",
+  "version": "4.1.0-beta.4",
   "description": "Unleash Client for Node",
   "license": "Apache-2.0",
   "main": "./lib/index.js",

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -232,9 +232,9 @@ export class Strategy {
       return variantDefinition ? {
         enabled: true,
         variant: {
-          name: variantDefinition?.name,
+          name: variantDefinition.name,
           enabled: true,
-          payload: variantDefinition?.payload,
+          payload: variantDefinition.payload,
         },
       } : { enabled: true };
     }

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -239,7 +239,7 @@ export class Strategy {
       } : { enabled: true };
     }
 
-    if(enabled) {
+    if (enabled) {
       return { enabled: true };
     }
 

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -167,7 +167,7 @@ operators.set(Operator.SEMVER_EQ, SemverOperator);
 operators.set(Operator.SEMVER_GT, SemverOperator);
 operators.set(Operator.SEMVER_LT, SemverOperator);
 
-export type StrategyResult = { enabled: true, variant?: Variant | null } | { enabled: false };
+export type StrategyResult = { enabled: true, variant?: Variant } | { enabled: false };
 
 export class Strategy {
   public name: string;

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -77,7 +77,7 @@ function findOverride(variants: VariantDefinition[],
 }
 
 export function selectVariantDefinition(
-  featureName: string,
+  groupId: string,
   variants: VariantDefinition[],
   context: Context,
 ): VariantDefinition | null {
@@ -92,7 +92,7 @@ export function selectVariantDefinition(
 
   const { stickiness } = variants[0];
 
-  const target = normalizedValue(getSeed(context, stickiness), featureName, totalWeight);
+  const target = normalizedValue(getSeed(context, stickiness), groupId, totalWeight);
 
   let counter = 0;
   const variant = variants.find((v: VariantDefinition): VariantDefinition | undefined => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* explicitly modelling strategy result as a discriminative union. We're discriminating on the enabled key.
* strategy variant calculation moved to the strategy instead of being spread between client and variant
* using strategy groupId for variant distribution instead of using feature name. groupId can be set to the feature name though. This change allows to set the same groupId across variants in different features strategies

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
