### PR TITLE
feat: force get variant with strategy variants

### DIFF
--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -323,7 +323,10 @@ export class Unleash extends EventEmitter {
     return variant;
   }
 
-  forceGetVariant(name: string, context: Context = {}, fallbackVariant?: Variant, forcedResult?: StrategyResult): Variant {
+  forceGetVariant(name: string,
+                  context: Context = {},
+                  fallbackVariant?: Variant,
+                  forcedResult?: StrategyResult): Variant {
     const enhancedContext = { ...this.staticContext, ...context };
     let result;
     if (this.ready) {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We'd like to avoid double evaluation of strategies when making 2 separate calls to check enabled status and get variant. 

* Adding new `evaluate` method that returns full StrategyResult with enabled status and optional variant. 
* forceGetVariant accepts optional StrategyResult parameter with a forced value
* as a bonus: moving parent dependency checking to one place 

We follow this pattern in playground. Now it will be possible to fix frontend API and proxy:
```ts
 return definitions
            .map((feature) => [feature, client.evaluate(feature.name, context)] as const)
            .filter(([,result]) => result.enabled)
            .map(([feature, result]) => ({
                name: feature.name,
                enabled: Boolean(feature.enabled),
                variant: client.forceGetVariant(feature.name, context, undefined, result),
                impressionData: Boolean(feature.impressionData),
            }));
```
In the code above we call evaluate to get enabled info + possible strategy variant. We can then pass the strategy variant to forceGetVariant to avoid double evaluation. 

This change has 2 new unit tests + was tested in the frontend API.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
