### PR TITLE
fix: restore removed public exports

### DIFF
--- a/src/variant.ts
+++ b/src/variant.ts
@@ -41,6 +41,16 @@ export const defaultVariant: Variant = {
   feature_enabled: false,
 };
 
+/**
+ * @deprecated Use `Variant` directly
+ */
+export interface VariantWithFeatureStatus extends Variant {}
+
+/**
+ * @deprecated Use `defaultVariant` directly
+ */
+export const getDefaultVariant = () => defaultVariant;
+
 function randomString() {
   return String(Math.round(Math.random() * 100000));
 }


### PR DESCRIPTION
## About the changes
Public interface `VariantWithFeatureStatus` and function `getDefaultVariant` was accidentally refactored out instead of being deprecated.