### PR TITLE
Fix: match variant and feature types with Unleash OpenAPI

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -153,7 +153,7 @@ export default class UnleashClient extends EventEmitter {
     feature.strategies?.some((strategySelector): boolean => {
       const strategy = this.getStrategy(strategySelector.name);
       if (!strategy) {
-        this.warnStrategyOnce(strategySelector.name, feature.name, feature.strategies);
+        this.warnStrategyOnce(strategySelector.name, feature.name, feature.strategies || []);
         return false;
       }
       const constraints = this.yieldConstraintsFor(strategySelector);

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -11,14 +11,14 @@ export interface Dependency {
 
 export interface FeatureInterface {
   name: string;
-  type: string;
-  project: string;
+  type?: string;
+  project?: string;
   description?: string;
   enabled: boolean;
-  stale: boolean;
-  impressionData: boolean;
-  strategies: StrategyTransportInterface[];
-  variants: VariantDefinition[];
+  stale?: boolean;
+  impressionData?: boolean;
+  strategies?: StrategyTransportInterface[];
+  variants?: VariantDefinition[];
   dependencies?: Dependency[];
 }
 

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -8,6 +8,7 @@ export enum PayloadType {
   STRING = 'string',
   JSON = 'json',
   CSV = 'csv',
+  NUMBER = 'number',
 }
 
 interface Override {
@@ -24,7 +25,7 @@ export interface VariantDefinition {
   name: string;
   weight: number;
   stickiness?: string;
-  payload: Payload;
+  payload?: Payload;
   overrides?: Override[];
 }
 
@@ -131,5 +132,5 @@ export function selectVariant(
   feature: FeatureInterface,
   context: Context,
 ): VariantDefinition | null {
-  return selectVariantDefinition(feature.name, feature.variants, context);
+  return selectVariantDefinition(feature.name, feature.variants || [], context);
 }


### PR DESCRIPTION
## About the changes
- Node SDK `FeatureInterface` was expecting fields not guaranteed to appear in the response from Unleash API.
- Added missing `number` variant payload type