### PR TITLE
feat: give option to retrieve toggle definitions with full segment data

### DIFF
--- a/src/feature.ts
+++ b/src/feature.ts
@@ -1,5 +1,5 @@
 import { StrategyTransportInterface } from './strategy';
-import { Segment } from './strategy/strategy';
+import { EnhancedStrategyTransportInterface, Segment } from './strategy/strategy';
 // eslint-disable-next-line import/no-cycle
 import { VariantDefinition } from './variant';
 
@@ -20,6 +20,10 @@ export interface FeatureInterface {
   strategies?: StrategyTransportInterface[];
   variants?: VariantDefinition[];
   dependencies?: Dependency[];
+}
+
+export interface EnhancedFeatureInterface extends Omit<FeatureInterface, 'strategies'> {
+  strategies?: EnhancedStrategyTransportInterface[]
 }
 
 export interface ClientFeaturesResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export function getFeatureToggleDefinition(toggleName: string) {
   return instance && instance.getFeatureToggleDefinition(toggleName);
 }
 
-export function getFeatureToggleDefinitions() {
-  return instance && instance.getFeatureToggleDefinitions();
+export function getFeatureToggleDefinitions(withFullSegments = false) {
+  return instance && instance.getFeatureToggleDefinitions(withFullSegments);
 }
 
 export function getVariant(

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -11,6 +11,11 @@ export interface StrategyTransportInterface {
   variants?: VariantDefinition[];
 }
 
+export interface EnhancedStrategyTransportInterface
+  extends Omit<StrategyTransportInterface, 'segments'> {
+  segments?: Array<Segment | undefined>
+}
+
 export interface Constraint {
   contextName: string;
   operator: Operator;

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -6,7 +6,7 @@ import Metrics from './metrics';
 import { Context } from './context';
 import { Strategy, defaultStrategies } from './strategy';
 
-import { FeatureInterface } from './feature';
+import { EnhancedFeatureInterface, FeatureInterface } from './feature';
 import { Variant, defaultVariant, VariantWithFeatureStatus } from './variant';
 import {
   FallbackFunction,
@@ -332,8 +332,15 @@ export class Unleash extends EventEmitter {
     return this.repository.getToggle(toggleName);
   }
 
-  getFeatureToggleDefinitions(): FeatureInterface[] {
-    return this.repository.getToggles();
+  getFeatureToggleDefinitions(
+    withFullSegments: boolean
+  ): Array<FeatureInterface | EnhancedFeatureInterface> {
+    const toggles =  this.repository.getToggles();
+
+    if (withFullSegments) {
+      return this.repository.enhanceWithSegmentData(toggles);
+    }
+    return toggles;
   }
 
   count(toggleName: string, enabled: boolean) {


### PR DESCRIPTION
This will give the option to retrieve toggle definitions with full segment data

Relates to [SR-353](https://linear.app/unleash/issue/SR-353/expose-getsegment-method-request-for-access-to-raw-segment-data)