### PR TITLE
fix: make exposing segment data backwards compatible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export function getFeatureToggleDefinition(toggleName: string) {
   return instance && instance.getFeatureToggleDefinition(toggleName);
 }
 
-export function getFeatureToggleDefinitions(withFullSegments = false) {
-  return instance && instance.getFeatureToggleDefinitions(withFullSegments);
+export function getFeatureToggleDefinitions(withFullSegments: boolean = false) {
+  return instance && instance.getFeatureToggleDefinitions(withFullSegments as any);
 }
 
 export function getVariant(

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -333,16 +333,14 @@ export class Unleash extends EventEmitter {
   }
 
   getFeatureToggleDefinitions(): Array<FeatureInterface>;
+  getFeatureToggleDefinitions(withFullSegments: true): Array<EnhancedFeatureInterface>;
   getFeatureToggleDefinitions(
-    withFullSegments: true
-  ): Array<EnhancedFeatureInterface>;
-  getFeatureToggleDefinitions(
-    withFullSegments = false
+    withFullSegments?: any
   ): Array<FeatureInterface | EnhancedFeatureInterface> {
-    if (withFullSegments) {
-      return this.repository.getTogglesWithSegmentData();
-    }
-    return this.repository.getToggles();;
+      if (withFullSegments === true) {
+        return this.repository.getTogglesWithSegmentData();
+      }
+      return this.repository.getToggles();
   }
 
   count(toggleName: string, enabled: boolean) {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -332,6 +332,10 @@ export class Unleash extends EventEmitter {
     return this.repository.getToggle(toggleName);
   }
 
+  getFeatureToggleDefinitions(): Array<FeatureInterface>;
+  getFeatureToggleDefinitions(
+    withFullSegments: true
+  ): Array<EnhancedFeatureInterface>;
   getFeatureToggleDefinitions(
     withFullSegments = false
   ): Array<FeatureInterface | EnhancedFeatureInterface> {


### PR DESCRIPTION
This PR makes the changes to `getFeatureToggleDefinitions` (ie exposing the segment data) backwards compatible by adding overload functions.

This will (appropriately) make the changes non breaking