### PR TITLE
fix: handle falsy context fields

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,10 +19,10 @@ export function createFallbackFunction(
 }
 
 export function resolveContextValue(context: Context, field: string): string | undefined {
-  if (context[field]) {
+  if (context[field] !== undefined) {
     return context[field]?.toString();
   }
-  if (context.properties && context.properties[field]) {
+  if (context.properties && context.properties[field] !== undefined) {
     return context.properties[field]?.toString();
   }
   return undefined;

--- a/src/test/integration/context.test.ts
+++ b/src/test/integration/context.test.ts
@@ -21,9 +21,12 @@ const mockNetwork = (flags: typeof FLAGS, url = getUrl()) => {
 };
 
 const FLAG = 'context.test.flag';
+const FLAG_FALSY = `${FLAG}-falsy`;
 const STRING_CTX = 'yes';
-const NUMBER_CTX = 7;
-const BOOL_CTX = true;
+const NUMBER_SEVEN_CTX = 7;
+const NUMBER_ZERO_CTX = 0;
+const BOOL_TRUE_CTX = true;
+const BOOL_FALSE_CTX = false;
 
 const FLAGS = {
   version: 1,
@@ -39,7 +42,24 @@ const FLAGS = {
             {
               contextName: 'test',
               operator: 'IN',
-              values: [STRING_CTX, NUMBER_CTX.toString(), BOOL_CTX.toString()],
+              values: [STRING_CTX, NUMBER_SEVEN_CTX.toString(), BOOL_TRUE_CTX.toString()],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: FLAG_FALSY,
+      description: 'Tests that falsy context values are properly handled',
+      enabled: true,
+      strategies: [
+        {
+          name: 'default',
+          constraints: [
+            {
+              contextName: 'test',
+              operator: 'IN',
+              values: [NUMBER_ZERO_CTX.toString(), BOOL_FALSE_CTX.toString()],
             },
           ],
         },
@@ -87,7 +107,7 @@ test('should be enabled for number context field', (t) =>
 
     instance.on('error', reject);
     instance.on('synchronized', () => {
-      const result = instance.isEnabled(FLAG, { properties: { test: NUMBER_CTX } });
+      const result = instance.isEnabled(FLAG, { properties: { test: NUMBER_SEVEN_CTX } });
       t.is(result, true);
       instance.destroy();
       resolve();
@@ -111,7 +131,7 @@ test('should be enabled for boolean context field', (t) =>
     instance.on('error', reject);
     instance.on('synchronized', () => {
       // @ts-expect-error
-      const result = instance.isEnabled(FLAG, { properties: { test: BOOL_CTX } });
+      const result = instance.isEnabled(FLAG, { properties: { test: BOOL_TRUE_CTX } });
       t.is(result, true);
       instance.destroy();
       resolve();
@@ -139,6 +159,53 @@ test('should gracefully handle null or undefined context fields', (t) =>
       t.is(result1, false);
       const result2 = instance.isEnabled(FLAG, { properties: { test: undefined } });
       t.is(result2, false);
+      instance.destroy();
+      resolve();
+    });
+  }));
+
+test('should support "0" as a number context field value', (t) =>
+  new Promise((resolve, reject) => {
+    // Mock unleash-api
+    const url = mockNetwork(FLAGS);
+
+    // New unleash instance
+    const instance = new Unleash({
+      appName: 'Test',
+      disableMetrics: true,
+      environment: 'test',
+      url,
+      backupPath: getRandomBackupPath('test-context'),
+    });
+
+    instance.on('error', reject);
+    instance.on('synchronized', () => {
+      const result = instance.isEnabled(FLAG_FALSY, { properties: { test: NUMBER_ZERO_CTX } });
+      t.is(result, true);
+      instance.destroy();
+      resolve();
+    });
+  }));
+
+test('should support "false" as a boolean context field value', (t) =>
+  new Promise((resolve, reject) => {
+    // Mock unleash-api
+    const url = mockNetwork(FLAGS);
+
+    // New unleash instance
+    const instance = new Unleash({
+      appName: 'Test',
+      disableMetrics: true,
+      environment: 'test',
+      url,
+      backupPath: getRandomBackupPath('test-context'),
+    });
+
+    instance.on('error', reject);
+    instance.on('synchronized', () => {
+      // @ts-expect-error
+      const result = instance.isEnabled(FLAG_FALSY, { properties: { test: BOOL_FALSE_CTX } });
+      t.is(result, true);
       instance.destroy();
       resolve();
     });


### PR DESCRIPTION
Follow up to https://github.com/Unleash/unleash-client-node/pull/628

I noticed we were not correctly handling falsy values in our context values due to doing a truthy check on the value when resolving it. 

By replacing that check with a more explicit `!== undefined` check we can still properly evaluate context fields such as `false` or `0`. I believe this check tracks with the original intent of simply checking whether the field is present.

Eventually all of this could be simplified to: `return context[field]?.toString() ?? context.properties?.[field]?.toString();`, but I wanted to avoid that level of refactor in this PR. I can still do it if the reviewer agrees.

Also added new tests that cover these specific cases.