### PR TITLE
feat: automatically generated instanceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ The initialize method takes the following arguments:
 - **environment** - The value to put in the Unleash context's `environment` property. Automatically
   populated in the Unleash Context (optional). This does **not** set the SDK's
   [Unleash environment](https://docs.getunleash.io/reference/environments).
-- **instanceId** - A unique identifier, should/could be somewhat unique.
 - **refreshInterval** - The poll interval to check for updates. Defaults to 15000ms.
 - **metricsInterval** - How often the client should send metrics to Unleash API. Defaults to
   60000ms.
@@ -229,6 +228,10 @@ The initialize method takes the following arguments:
 - **namePrefix** - Only fetch feature toggles with the provided name prefix.
 - **tags** - Only fetch feature toggles tagged with the list of tags. E.g.:
   `[{type: 'simple', value: 'proxy'}]`.
+
+### instanceId
+
+As of version 5.0.0, `instanceId` is now automatically generated.
 
 ## Custom strategies
 
@@ -379,13 +382,12 @@ import {
   initialize,
   getFeatureToggleDefinition,
   getFeatureToggleDefinitions,
-} from "unleash-client";
+} from 'unleash-client';
 
 initialize({
   url: 'http://unleash.herokuapp.com/api/',
   customHeaders: { Authorization: '<YOUR_API_TOKEN>' },
   appName: 'my-app-name',
-  instanceId: 'my-unique-instance-id',
 });
 
 const featureToggleX = getFeatureToggleDefinition('app.ToggleX');
@@ -404,7 +406,7 @@ provider or a custom store provider implemented by you.
 **1. Use InMemStorageProvider**
 
 ```js
-import { initialize, InMemStorageProvider } from "unleash-client";
+import { initialize, InMemStorageProvider } from 'unleash-client';
 
 const client = initialize({
   appName: 'my-application',
@@ -417,7 +419,7 @@ const client = initialize({
 **2. Custom Store Provider backed by redis**
 
 ```js
-import { initialize, InMemStorageProvider } from "unleash-client";
+import { initialize, InMemStorageProvider } from 'unleash-client';
 
 import { createClient } from 'redis';
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,3 @@
-import { userInfo, hostname } from 'os';
 import * as murmurHash3 from 'murmurhash3js';
 import { Context } from './context';
 
@@ -24,23 +23,6 @@ export function resolveContextValue(context: Context, field: string): string | u
 
 export function safeName(str: string = '') {
   return str.replace(/\//g, '_');
-}
-
-export function generateInstanceId(instanceId?: string): string {
-  if (instanceId) {
-    return instanceId;
-  }
-  let info;
-  try {
-    info = userInfo();
-  } catch (e) {
-    // unable to read info;
-  }
-
-  const prefix = info
-    ? info.username
-    : `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
-  return `${prefix}-${hostname()}`;
 }
 
 export function generateHashOfConfig(o: Object): string {

--- a/src/unleash-config.ts
+++ b/src/unleash-config.ts
@@ -11,7 +11,6 @@ import { RepositoryInterface } from './repository';
 export interface UnleashConfig {
   appName: string;
   environment?: string;
-  instanceId?: string;
   url: string;
   refreshInterval?: number;
   projectName?: string;

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -1,4 +1,5 @@
 import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
 import Client from './client';
 import Repository, { RepositoryInterface } from './repository';
@@ -8,12 +9,7 @@ import { Strategy, defaultStrategies } from './strategy';
 
 import { EnhancedFeatureInterface, FeatureInterface } from './feature';
 import { Variant, defaultVariant, VariantWithFeatureStatus } from './variant';
-import {
-  FallbackFunction,
-  createFallbackFunction,
-  generateInstanceId,
-  generateHashOfConfig,
-} from './helpers';
+import { FallbackFunction, createFallbackFunction, generateHashOfConfig } from './helpers';
 import { resolveBootstrapProvider } from './repository/bootstrap-provider';
 import { ImpressionEvent, UnleashEvents } from './events';
 import { UnleashConfig } from './unleash-config';
@@ -53,7 +49,6 @@ export class Unleash extends EventEmitter {
     appName,
     environment = 'default',
     projectName,
-    instanceId,
     url,
     refreshInterval = 15 * 1000,
     metricsInterval = 60 * 1000,
@@ -101,7 +96,7 @@ export class Unleash extends EventEmitter {
 
     const unleashUrl = this.cleanUnleashUrl(url);
 
-    const unleashInstanceId = generateInstanceId(instanceId);
+    const unleashInstanceId = randomUUID();
 
     this.staticContext = { appName, environment };
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2397/make-instance-id-autogenned-node

This makes `instanceId` an automatically generated property, instead of being set by the user.

Similar to https://github.com/Unleash/unleash-client-ruby/pull/179
Similar to https://github.com/Unleash/unleash-client-dotnet/pull/226