### PR TITLE
feat: http and https proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ offline, from a browser environment or implement your own caching layer. See
 Unleash depends on a `ready` event of the repository you pass in. Be sure that you emit the event
 **after** you've initialized unleash.
 
+## Usage with HTTP and HTTPS proxies
+
+You can connect to the Unleash API through the corporate proxy by setting one of the environment
+variables: `HTTP_PROXY` or `HTTPS_PROXY`
+
 ## Design philosophy
 
 This feature flag SDK is designed according to our design philosophy. You can

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "dependencies": {
     "ip-address": "^9.0.5",
     "make-fetch-happen": "^13.0.1",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.5",
     "murmurhash3js": "^3.0.1",
     "semver": "^7.6.2"
   },

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,6 @@
 import * as fetch from 'make-fetch-happen';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as http from 'http';
 import * as https from 'https';
 import { URL } from 'url';
@@ -29,17 +31,23 @@ export interface PostRequestOptions extends RequestOptions {
   instanceId?: string;
   httpOptions?: HttpOptions;
 }
-const httpAgent = new http.Agent({
-  keepAlive: true,
-  keepAliveMsecs: 30 * 1000,
-  timeout: 10 * 1000,
-});
 
-const httpsAgent = new https.Agent({
+const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
+const httpAgentOptions: http.AgentOptions = {
   keepAlive: true,
   keepAliveMsecs: 30 * 1000,
   timeout: 10 * 1000,
-});
+};
+
+const httpAgent = httpProxy
+  ? new HttpProxyAgent(httpProxy, httpAgentOptions)
+  : new http.Agent(httpAgentOptions);
+
+const httpsAgent = httpsProxy
+  ? new HttpsProxyAgent(httpsProxy, httpAgentOptions)
+  : new https.Agent(httpAgentOptions);
 
 export const getDefaultAgent = (url: URL) => (url.protocol === 'https:' ? httpsAgent : httpAgent);
 export const buildHeaders = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,7 +2723,7 @@ http-cache-semantics@^4.1.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
-http-proxy-agent@^7.0.0:
+http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
   integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
@@ -2744,6 +2744,14 @@ https-proxy-agent@^7.0.1:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
   integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
+
+https-proxy-agent@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz#9e8b5013873299e11fab6fd548405da2d6c602b2"
+  integrity sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==
   dependencies:
     agent-base "^7.0.2"
     debug "4"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Support for HTTP_PROXY and HTTPS_PROXY

E.g. If you have a proxy at http://localhost:8081 pointing to your Unleash API URL run your app that contains the Node SDK with: `HTTP_PROXY=http://localhost:8081 node my_app.js`

Design decision:
* instead of using @npmcli/agent directly that does the env var detection I decided to implement detection myself and instantiate http and https proxies directly. Those are the same proxies that the @npmcli/agent instantiates. The reason I choose to do it myself is because @npmcli/agent doesn't have any TS types and we loose autocompletion. On the other hand the low level agents have built-in TS support. 

Can be tested locally with https://github.com/kwasniew/proxy-server

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
