### PR TITLE
feat: extend metrics with metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The initialize method takes the following arguments:
 
 ### instanceId
 
-As of version 5.0.0, `instanceId` is now automatically generated.
+As of version 6.0.0, `instanceId` is now automatically generated.
 
 ## Custom strategies
 

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -14,7 +14,7 @@ import {
   StrategyTransportInterface,
 } from '../strategy/strategy';
 
-const SUPPORTED_SPEC_VERSION = '4.3.0';
+export const SUPPORTED_SPEC_VERSION = '4.3.0';
 
 export interface RepositoryInterface extends EventEmitter {
   getToggle(name: string): FeatureInterface | undefined;

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import * as nock from 'nock';
 import Metrics from '../metrics';
+import { SUPPORTED_SPEC_VERSION } from '../repository';
 
 let counter = 1;
 const getUrl = () => `http://test${counter++}.app/`;
@@ -554,4 +555,34 @@ test('sendMetrics should backoff on 429 and gradually reduce interval', async (t
   t.false(metrics.disabled);
   t.is(metrics.getFailures(), 0);
   t.is(metrics.getInterval(), metricsInterval);
+});
+
+test('getClientData should include extended metrics', (t) => {
+  const url = getUrl();
+  // @ts-expect-error
+  const metrics = new Metrics({
+    url,
+  });
+  metrics.start();
+
+  const result = metrics.getClientData();
+  t.truthy(result.platformName);
+  t.truthy(result.platformVersion);
+  t.true(result.yggdrasilVersion === null);
+  t.true(result.specVersion === SUPPORTED_SPEC_VERSION);
+});
+
+test('createMetricsData should include extended metrics', (t) => {
+  const url = getUrl();
+  // @ts-expect-error
+  const metrics = new Metrics({
+    url,
+  });
+  metrics.start();
+
+  const result = metrics.createMetricsData();
+  t.truthy(result.platformName);
+  t.truthy(result.platformVersion);
+  t.true(result.yggdrasilVersion === null);
+  t.true(result.specVersion === SUPPORTED_SPEC_VERSION);
 });


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2389/extend-node-sdk-with-new-metrics

This extends the current metrics with metadata.

Tries being a bit fancy and grab other runtimes like `bun` and `deno`. E.g. if we run something in Bun that uses our SDK we can see it in the metrics payload:
![image](https://github.com/Unleash/unleash-client-node/assets/14320932/8e90b54b-ad9b-4149-8eb4-93e9f77024ec)

Similar to: https://github.com/Unleash/unleash-client-dotnet/pull/231 and https://github.com/Unleash/unleash-client-ruby/pull/177