### PR TITLE
chore: revert automatically generated instanceId (#637)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The initialize method takes the following arguments:
 - **environment** - The value to put in the Unleash context's `environment` property. Automatically
   populated in the Unleash Context (optional). This does **not** set the SDK's
   [Unleash environment](https://docs.getunleash.io/reference/environments).
+- **instanceId** - A unique identifier, should/could be somewhat unique.
 - **refreshInterval** - The poll interval to check for updates. Defaults to 15000ms.
 - **metricsInterval** - How often the client should send metrics to Unleash API. Defaults to
   60000ms.
@@ -228,10 +229,6 @@ The initialize method takes the following arguments:
 - **namePrefix** - Only fetch feature toggles with the provided name prefix.
 - **tags** - Only fetch feature toggles tagged with the list of tags. E.g.:
   `[{type: 'simple', value: 'proxy'}]`.
-
-### instanceId
-
-As of version 6.0.0, `instanceId` is now automatically generated.
 
 ## Custom strategies
 
@@ -388,6 +385,7 @@ initialize({
   url: 'http://unleash.herokuapp.com/api/',
   customHeaders: { Authorization: '<YOUR_API_TOKEN>' },
   appName: 'my-app-name',
+  instanceId: 'my-unique-instance-id',
 });
 
 const featureToggleX = getFeatureToggleDefinition('app.ToggleX');

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { userInfo, hostname } from 'os';
 import * as murmurHash3 from 'murmurhash3js';
 import { Context } from './context';
 
@@ -23,6 +24,23 @@ export function resolveContextValue(context: Context, field: string): string | u
 
 export function safeName(str: string = '') {
   return str.replace(/\//g, '_');
+}
+
+export function generateInstanceId(instanceId?: string): string {
+  if (instanceId) {
+    return instanceId;
+  }
+  let info;
+  try {
+    info = userInfo();
+  } catch (e) {
+    // unable to read info;
+  }
+
+  const prefix = info
+    ? info.username
+    : `generated-${Math.round(Math.random() * 1000000)}-${process.pid}`;
+  return `${prefix}-${hostname()}`;
 }
 
 export function generateHashOfConfig(o: Object): string {

--- a/src/unleash-config.ts
+++ b/src/unleash-config.ts
@@ -11,6 +11,7 @@ import { RepositoryInterface } from './repository';
 export interface UnleashConfig {
   appName: string;
   environment?: string;
+  instanceId?: string;
   url: string;
   refreshInterval?: number;
   projectName?: string;

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -1,5 +1,4 @@
 import { tmpdir } from 'os';
-import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
 import Client from './client';
 import Repository, { RepositoryInterface } from './repository';
@@ -9,7 +8,12 @@ import { Strategy, defaultStrategies } from './strategy';
 
 import { EnhancedFeatureInterface, FeatureInterface } from './feature';
 import { Variant, defaultVariant, VariantWithFeatureStatus } from './variant';
-import { FallbackFunction, createFallbackFunction, generateHashOfConfig } from './helpers';
+import {
+  FallbackFunction,
+  createFallbackFunction,
+  generateInstanceId,
+  generateHashOfConfig,
+} from './helpers';
 import { resolveBootstrapProvider } from './repository/bootstrap-provider';
 import { ImpressionEvent, UnleashEvents } from './events';
 import { UnleashConfig } from './unleash-config';
@@ -49,6 +53,7 @@ export class Unleash extends EventEmitter {
     appName,
     environment = 'default',
     projectName,
+    instanceId,
     url,
     refreshInterval = 15 * 1000,
     metricsInterval = 60 * 1000,
@@ -96,7 +101,7 @@ export class Unleash extends EventEmitter {
 
     const unleashUrl = this.cleanUnleashUrl(url);
 
-    const unleashInstanceId = randomUUID();
+    const unleashInstanceId = generateInstanceId(instanceId);
 
     this.staticContext = { appName, environment };
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2427/revert-autogenned-instance-id-node

Reverts: https://github.com/Unleash/unleash-client-node/pull/637