### PR TITLE
chore: drop strict check in semver in favor of checking it is valid

### DIFF
--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -51,7 +51,8 @@ export enum Operator {
 export type OperatorImpl = (constraint: Constraint, context: Context) => boolean;
 
 const cleanValues = (values: string[]) => values.filter((v) => !!v).map((v) => v.trim());
-const isValidSemver = (version: string) => Boolean(validSemver(version));
+const isValidSemver = (version: string) =>
+  Boolean(validSemver(version)) && !version.startsWith('v');
 
 const InOperator = (constraint: Constraint, context: Context) => {
   const field = constraint.contextName;

--- a/src/strategy/strategy.ts
+++ b/src/strategy/strategy.ts
@@ -1,4 +1,4 @@
-import { gt as semverGt, lt as semverLt, eq as semverEq, clean as cleanSemver } from 'semver';
+import { gt as semverGt, lt as semverLt, eq as semverEq, valid as validSemver } from 'semver';
 import { Context } from '../context';
 import { resolveContextValue } from '../helpers';
 import { selectVariantDefinition, Variant, VariantDefinition } from '../variant';
@@ -51,7 +51,7 @@ export enum Operator {
 export type OperatorImpl = (constraint: Constraint, context: Context) => boolean;
 
 const cleanValues = (values: string[]) => values.filter((v) => !!v).map((v) => v.trim());
-const isStrictSemver = (version: string) => cleanSemver(version) === version;
+const isValidSemver = (version: string) => Boolean(validSemver(version));
 
 const InOperator = (constraint: Constraint, context: Context) => {
   const field = constraint.contextName;
@@ -98,7 +98,7 @@ const SemverOperator = (constraint: Constraint, context: Context) => {
   }
 
   try {
-    if (!isStrictSemver(contextValue)) {
+    if (!isValidSemver(contextValue)) {
       return false;
     }
     if (operator === Operator.SEMVER_EQ) {

--- a/src/test/strategy/strategy.test.ts
+++ b/src/test/strategy/strategy.test.ts
@@ -520,7 +520,7 @@ test('should be enabled when semver in range', (t) => {
     { contextName: 'version', operator: 'SEMVER_LT', value: '2.0.0' },
   ];
 
-  for (const version of ['1.2.5', '1.2.5+1235', '1.2.5-rc.1', 'v1.2.5']) {
+  for (const version of ['1.2.5', '1.2.5+1235', '1.2.5-rc.1']) {
     const context = {
       environment: 'dev',
       properties: { version },

--- a/src/test/strategy/strategy.test.ts
+++ b/src/test/strategy/strategy.test.ts
@@ -520,12 +520,15 @@ test('should be enabled when semver in range', (t) => {
     { contextName: 'version', operator: 'SEMVER_LT', value: '2.0.0' },
   ];
 
-  const context = {
-    environment: 'dev',
-    properties: { version: '1.2.5' },
-  };
-  // @ts-expect-error
-  t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+  for (const version of ['1.2.5', '1.2.5+1235', '1.2.5-rc.1', 'v1.2.5']) {
+    const context = {
+      environment: 'dev',
+      properties: { version },
+    };
+
+    // @ts-expect-error
+    t.true(strategy.isEnabledWithConstraints(params, context, constraints));
+  }
 });
 
 test('should be disabled when semver out of range', (t) => {


### PR DESCRIPTION
This drops the strictness check in our semver strategy constraints in favor of checking whether the semver is valid.

We found this out by trying to create a semver constraint for ourselves using the Unleash semver format (x.x.x+hash)