### PR TITLE
fix: retry all streaming errors

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -132,8 +132,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
     this.segments = new Map();
     this.eventSource = eventSource;
     if (this.eventSource) {
-      // on first connect it replicates the fetch from the start() call.
-      // On re-connect it guaranteed catching up with the latest state.
+      // On re-connect it guarantees catching up with the latest state.
       this.eventSource.addEventListener('unleash-connected', (event: { data: string }) => {
         // reconnect
         if (this.initialEventSourceConnected) {

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1362,7 +1362,7 @@ test('Stopping repository should stop storage provider updates', async (t) => {
   t.is(result, undefined);
 });
 
-test('Streaming update events', async (t) => {
+test('Streaming', async (t) => {
   t.plan(7);
   const url = 'http://unleash-test-streaming.app';
   const feature = {

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1362,9 +1362,9 @@ test('Stopping repository should stop storage provider updates', async (t) => {
   t.is(result, undefined);
 });
 
-test('Streaming', async (t) => {
-  t.plan(6);
-  const url = 'irrelevant';
+test('Streaming update events', async (t) => {
+  t.plan(7);
+  const url = 'http://unleash-test-streaming.app';
   const feature = {
     name: 'feature',
     enabled: true,
@@ -1374,6 +1374,7 @@ test('Streaming', async (t) => {
       },
     ],
   };
+  setup(url, [{ ...feature, name: 'initialFetch' }]);
   const storageProvider: StorageProvider<ClientFeaturesResponse> = new InMemStorageProvider();
   const eventSource = {
     eventEmitter: new EventEmitter(),
@@ -1402,16 +1403,24 @@ test('Streaming', async (t) => {
     eventSource,
   });
 
+  await repo.start();
+
+  // first connection is ignored, since we do regular fetch
+  eventSource.emit('unleash-connected', {
+    type: 'unleash-connected',
+    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'intialConnectedIgnored' }] }),
+  });
+
   const before = repo.getToggles();
-  t.deepEqual(before, []);
+  t.deepEqual(before, [{ ...feature, name: 'initialFetch' }]);
 
   // update with feature
   eventSource.emit('unleash-updated', {
     type: 'unleash-updated',
-    data: JSON.stringify({ meta: {}, features: [feature] }),
+    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'firstUpdate' }] }),
   });
   const firstUpdate = repo.getToggles();
-  t.deepEqual(firstUpdate, [feature]);
+  t.deepEqual(firstUpdate, [{ ...feature, name: 'firstUpdate' }]);
   // @ts-expect-error
   t.is(repo.etag, undefined);
 
@@ -1430,4 +1439,12 @@ test('Streaming', async (t) => {
     t.is(msg, 'some error');
   });
   eventSource.emit('error', 'some error');
+
+  // re-connect simulation
+  eventSource.emit('unleash-connected', {
+    type: 'unleash-connected',
+    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'reconnectUpdate' }] }),
+  });
+  const reconnectUpdate = repo.getToggles();
+  t.deepEqual(reconnectUpdate, [{ ...feature, name: 'reconnectUpdate' }]);
 });

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -143,6 +143,10 @@ export class Unleash extends EventEmitter {
                 maxBackoffMillis: 30000,
                 retryResetIntervalMillis: 60000,
                 jitterRatio: 0.5,
+                errorFilter: function () {
+                  // retry all errors
+                  return true;
+                },
               })
             : undefined,
         storageProvider: storageProvider || new FileStorageProvider(backupPath),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Improving retry on streaming behavior.
Previously we were only retrying on 500 codes.

Details:
* handling unleash-connected event but we ignore it on first connect. First connect is done with a regular fetch for a safety fallback e.g. when server doesn't support streaming
* telling eventsource client to retry all types of errors so when some network proxy ends the connection without sending HTTP code we still re-connect and refetch the features from the unleash-connected event data (no data updated during proxy downtime is lost as a result)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
