### PR TITLE
fix: remove etag from streaming parsing

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -150,13 +150,7 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
   private handleFlagsFromStream(event: { data: string }) {
     try {
-      const data: ClientFeaturesResponse & { meta: { etag: string } } = JSON.parse(event.data);
-      const etag = data.meta.etag;
-      if (etag !== null) {
-        this.etag = etag;
-      } else {
-        this.etag = undefined;
-      }
+      const data: ClientFeaturesResponse = JSON.parse(event.data);
       this.save(data, true);
     } catch (err) {
       this.emit(UnleashEvents.Error, err);

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1363,7 +1363,7 @@ test('Stopping repository should stop storage provider updates', async (t) => {
 });
 
 test('Streaming', async (t) => {
-  t.plan(7);
+  t.plan(5);
   const url = 'http://unleash-test-streaming.app';
   const feature = {
     name: 'feature',
@@ -1408,7 +1408,7 @@ test('Streaming', async (t) => {
   // first connection is ignored, since we do regular fetch
   eventSource.emit('unleash-connected', {
     type: 'unleash-connected',
-    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'intialConnectedIgnored' }] }),
+    data: JSON.stringify({ features: [{ ...feature, name: 'intialConnectedIgnored' }] }),
   });
 
   const before = repo.getToggles();
@@ -1417,22 +1417,17 @@ test('Streaming', async (t) => {
   // update with feature
   eventSource.emit('unleash-updated', {
     type: 'unleash-updated',
-    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'firstUpdate' }] }),
+    data: JSON.stringify({ features: [{ ...feature, name: 'firstUpdate' }] }),
   });
   const firstUpdate = repo.getToggles();
   t.deepEqual(firstUpdate, [{ ...feature, name: 'firstUpdate' }]);
-  // @ts-expect-error
-  t.is(repo.etag, undefined);
 
-  // update with etag
   eventSource.emit('unleash-updated', {
     type: 'unleash-updated',
-    data: JSON.stringify({ meta: { etag: 'updated' }, features: [] }),
+    data: JSON.stringify({ features: [] }),
   });
   const secondUpdate = repo.getToggles();
   t.deepEqual(secondUpdate, []);
-  // @ts-expect-error
-  t.is(repo.etag, 'updated');
 
   // SSE error translated to repo warning
   repo.on('warn', (msg) => {
@@ -1443,7 +1438,7 @@ test('Streaming', async (t) => {
   // re-connect simulation
   eventSource.emit('unleash-connected', {
     type: 'unleash-connected',
-    data: JSON.stringify({ meta: {}, features: [{ ...feature, name: 'reconnectUpdate' }] }),
+    data: JSON.stringify({ features: [{ ...feature, name: 'reconnectUpdate' }] }),
   });
   const reconnectUpdate = repo.getToggles();
   t.deepEqual(reconnectUpdate, [{ ...feature, name: 'reconnectUpdate' }]);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Since edge doesn't return meta in streaming response and we don't have any use case for streaming etags I'm removing it for now. Etag may become useful when we switch between streaming and polling at runtime so that polling can know latest etag from the last streaming update.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
