### PR TITLE
test: make regexes less strict for unleash version

### DIFF
--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -130,12 +130,12 @@ test('should send correct custom and x-unleash headers', (t) =>
     const metricsEP = nockMetrics(url)
       .matchHeader('randomKey', randomKey)
       .matchHeader('x-unleash-appname', 'appName')
-      .matchHeader('x-unleash-sdk', /^unleash-node@(\d+\.\d+\.\d+)$/)
+      .matchHeader('x-unleash-sdk', /^unleash-node@\d+\.\d+\.\d+/)
       .matchHeader('x-unleash-connection-id', 'connectionId');
     const regEP = nockRegister(url)
       .matchHeader('randomKey', randomKey)
       .matchHeader('x-unleash-appname', 'appName')
-      .matchHeader('x-unleash-sdk', /^unleash-node@(\d+\.\d+\.\d+)$/)
+      .matchHeader('x-unleash-sdk', /^unleash-node@\d+\.\d+\.\d+/)
       .matchHeader('x-unleash-connection-id', 'connectionId');
 
     // @ts-expect-error

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -191,7 +191,7 @@ test('should request with correct custom and x-unleash headers', (t) =>
       .matchHeader('randomKey', randomKey)
       .matchHeader('x-unleash-appname', appName)
       .matchHeader('x-unleash-connection-id', connectionId)
-      .matchHeader('x-unleash-sdk', /^unleash-node@(\d+\.\d+\.\d+)$/)
+      .matchHeader('x-unleash-sdk', /^unleash-node@\d+\.\d+\.\d+/)
       .persist()
       .get('/client/features')
       .reply(200, { features: [] }, { Etag: '12345-3' });

--- a/src/test/request.test.ts
+++ b/src/test/request.test.ts
@@ -29,5 +29,5 @@ test('Correct headers should be included', (t) => {
   t.is(headers['UNLEASH-INSTANCEID'], 'instanceId');
   t.is(headers['x-unleash-connection-id'], 'connectionId');
   t.is(headers['x-unleash-appname'], 'myApp');
-  t.regex(headers['x-unleash-sdk'], /^unleash-node@(\d+\.\d+\.\d+)$/);
+  t.regex(headers['x-unleash-sdk'], /^unleash-node@\d+\.\d+\.\d+/);
 });


### PR DESCRIPTION
This fix makes it so that beta versions (e.g. 4.0.6-beta.06) *don't* break it.