### PR TITLE
fix: drop ts type inference for event source

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -46,3 +46,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-as-dependency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - name: Yarn
+        run: yarn
+      - name: Test install in other package
+        run: ./scripts/test-package/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/Release
 # typescript lives in src, output in lib
 lib/
 .vscode
+
+# test files
+/test-package

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/make-fetch-happen": "^10.0.4",
     "@types/murmurhash3js": "^3.0.3",
     "@types/nock": "^11.1.0",
-    "@types/node": "^20.2.5",
+    "@types/node": "^20.17.17",
     "@types/proxy-from-env": "^1.0.4",
     "@types/semver": "^7.5.0",
     "@types/sinon": "^17.0.0",

--- a/scripts/test-package/run.sh
+++ b/scripts/test-package/run.sh
@@ -2,8 +2,8 @@
 set -e
 
 TEST_DIR="test-package"
-
 mkdir "$TEST_DIR"
+
 cp scripts/test-package/test-tsconfig.json "$TEST_DIR/tsconfig.json"
 cp scripts/test-package/test-package.json "$TEST_DIR/package.json"
 cd "$TEST_DIR"
@@ -11,5 +11,13 @@ npm install --install-links
 mkdir src
 echo -e "import { Unleash } from 'unleash-client';\nvoid Unleash;\nconsole.log('Hello world');" > src/index.ts
 ./node_modules/.bin/tsc -b tsconfig.json
-cd ..
-rm -rf "$TEST_DIR"
+
+if [ "$(node . 2>&1)" = "Hello world" ]; then
+  echo "Output is correct"
+  (cd .. && rm -rf "$TEST_DIR")
+else
+  echo "Output is incorrect" >&2
+  echo $(node . 2>&1)
+  (cd .. && rm -rf "$TEST_DIR")
+  exit 1
+fi

--- a/scripts/test-package/run.sh
+++ b/scripts/test-package/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo -e "\nTesting that the package can be installed in another project and compiled with TypeScript without errors"
+
 TEST_DIR="test-package"
 mkdir "$TEST_DIR"
 

--- a/scripts/test-package/run.sh
+++ b/scripts/test-package/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+TEST_DIR="test-package"
+
+mkdir "$TEST_DIR"
+cp scripts/test-package/test-tsconfig.json "$TEST_DIR/tsconfig.json"
+cp scripts/test-package/test-package.json "$TEST_DIR/package.json"
+cd "$TEST_DIR"
+npm install --install-links
+mkdir src
+echo -e "import { Unleash } from 'unleash-client';\nvoid Unleash;\nconsole.log('Hello world');" > src/index.ts
+./node_modules/.bin/tsc -b tsconfig.json
+cd ..
+rm -rf "$TEST_DIR"

--- a/scripts/test-package/test-package.json
+++ b/scripts/test-package/test-package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  },
+  "dependencies": {
+    "unleash-client": "file:.."
+  }
+}

--- a/scripts/test-package/test-tsconfig.json
+++ b/scripts/test-package/test-tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "declaration": true,
+    "inlineSourceMap": true,
+    "pretty": true,
+    "noImplicitAny": true,
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "composite": true,
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/src/event-source.js
+++ b/src/event-source.js
@@ -1,0 +1,3 @@
+import { EventSource as moduleToPatch } from 'launchdarkly-eventsource';
+
+export const EventSource = moduleToPatch;

--- a/src/event-source.js
+++ b/src/event-source.js
@@ -1,3 +1,3 @@
 import { EventSource as moduleToPatch } from 'launchdarkly-eventsource';
 
-export const EventSource = moduleToPatch;
+export const EventSource = moduleToPatch; // Re-export from .js file, because the original module doesn't have types

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -97,7 +97,7 @@ export default class Metrics extends EventEmitter {
 
   private url: string;
 
-  private timer: NodeJS.Timer | undefined;
+  private timer: NodeJS.Timeout | undefined;
 
   private started: Date;
 

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -49,7 +49,7 @@ interface FeatureToggleData {
 }
 
 export default class Repository extends EventEmitter implements EventEmitter {
-  private timer: NodeJS.Timer | undefined;
+  private timer: NodeJS.Timeout | undefined;
 
   private url: string;
 

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -13,8 +13,7 @@ import {
   Segment,
   StrategyTransportInterface,
 } from '../strategy/strategy';
-// @ts-expect-error
-import { EventSource } from 'launchdarkly-eventsource';
+import type { EventSource } from '../event-source';
 
 export const SUPPORTED_SPEC_VERSION = '4.3.0';
 

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1413,7 +1413,7 @@ test('Streaming', async (t) => {
   };
   setup(url, [{ ...feature, name: 'initialFetch' }]);
   const storageProvider: StorageProvider<ClientFeaturesResponse> = new InMemStorageProvider();
-  const eventSource = {
+  const eventSource: any = {
     eventEmitter: new EventEmitter(),
     listeners: new Set<string>(),
     addEventListener(eventName: string, handler: () => void) {
@@ -1421,7 +1421,7 @@ test('Streaming', async (t) => {
       eventSource.eventEmitter.on(eventName, handler);
     },
     close() {
-      eventSource.listeners.forEach((eventName) => {
+      eventSource.listeners.forEach((eventName: string) => {
         eventSource.eventEmitter.removeAllListeners(eventName);
       });
     },
@@ -1429,6 +1429,7 @@ test('Streaming', async (t) => {
       eventSource.eventEmitter.emit(eventName, data);
     },
   };
+
   const repo = new Repository({
     url,
     appName,

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -19,8 +19,7 @@ import { ImpressionEvent, UnleashEvents } from './events';
 import { UnleashConfig } from './unleash-config';
 import FileStorageProvider from './repository/storage-provider-file';
 import { resolveUrl } from './url-utils';
-// @ts-expect-error
-import { EventSource } from 'launchdarkly-eventsource';
+import { EventSource } from './event-source';
 import { buildHeaders } from './request';
 import { uuidv4 } from './uuidv4';
 export { Strategy, UnleashEvents, UnleashConfig };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "declarationMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": false,
+    "allowJs": true,
     "skipLibCheck": false
   },
-  "exclude": ["examples/", "lib/", "node_modules/"]
+  "exclude": ["examples/", "lib/", "node_modules/"],
+  "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,10 +731,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.2.5":
-  version "20.4.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.0.tgz#01d637d1891e419bc85763b46f42809cd2d5addb"
-  integrity sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==
+"@types/node@^20.17.17":
+  version "20.17.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.17.tgz#5cea2af2e271313742c14f418eaf5dcfa8ae2e3a"
+  integrity sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -5104,6 +5106,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 unique-filename@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## About the changes
- fix error with dependency typings
- add test to catch install issues in the future
- update Node types, to build without errors

Closes https://github.com/Unleash/unleash-client-node/issues/705
Internal ticket: [issue/1-3339/node-sdk-missing-dependency-for-types](https://linear.app/unleash/issue/1-3339/node-sdk-missing-dependency-for-types)
