### PR TITLE
chore: add a proxy decorator to the client so we can add impact metrics unobtrusively

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { UnleashConfig } from './unleash-config';
 export { Strategy } from './strategy/index';
 export { Context, Variant, PayloadType, Unleash, TagFilter, InMemStorageProvider, UnleashEvents };
 export type { ClientFeaturesResponse, UnleashConfig };
+export { UnleashMetricClient } from './metric-client';
 
 let instance: undefined | Unleash;
 

--- a/src/metric-client.ts
+++ b/src/metric-client.ts
@@ -1,0 +1,31 @@
+import { Unleash } from './unleash';
+
+function forwardMethods<T extends object>(target: T, source: T, methodNames: (keyof T)[]) {
+  for (const name of methodNames) {
+    // @ts-ignore
+    target[name] = (...args: any[]) => source[name](...args);
+  }
+}
+
+export class UnleashMetricClient {
+  private backingInstance: Unleash;
+
+  constructor(unleash: Unleash) {
+    this.backingInstance = unleash;
+    forwardMethods(this, this.backingInstance as any, [
+      'isEnabled',
+      'getVariant',
+      'forceGetVariant',
+      'getFeatureToggleDefinition',
+      'getFeatureToggleDefinitions',
+      'count',
+      'countVariant',
+      'flushMetrics',
+      'destroyWithFlush',
+      'on',
+      'start',
+      'destroy',
+      'isSynchronized',
+    ]);
+  }
+}

--- a/src/metric-client.ts
+++ b/src/metric-client.ts
@@ -1,10 +1,6 @@
 import { Unleash } from './unleash';
 
-function forwardMethods<T extends object>(
-  target: UnleashMetricClient,
-  source: Unleash,
-  methodNames: (keyof T)[],
-) {
+function forwardMethods<T extends object>(target: T, source: T, methodNames: (keyof T)[]) {
   for (const name of methodNames) {
     // @ts-ignore
     target[name] = (...args: any[]) => source[name](...args);
@@ -16,7 +12,7 @@ export class UnleashMetricClient {
 
   constructor(unleash: Unleash) {
     this.backingInstance = unleash;
-    forwardMethods(this, this.backingInstance, [
+    forwardMethods(this, this.backingInstance as any, [
       'isEnabled',
       'getVariant',
       'forceGetVariant',
@@ -32,4 +28,30 @@ export class UnleashMetricClient {
       'isSynchronized',
     ]);
   }
+
+  isEnabled!: Unleash['isEnabled'];
+
+  getVariant!: Unleash['getVariant'];
+
+  forceGetVariant!: Unleash['forceGetVariant'];
+
+  getFeatureToggleDefinition!: Unleash['getFeatureToggleDefinition'];
+
+  getFeatureToggleDefinitions!: Unleash['getFeatureToggleDefinitions'];
+
+  count!: Unleash['count'];
+
+  countVariant!: Unleash['countVariant'];
+
+  flushMetrics!: Unleash['flushMetrics'];
+
+  destroyWithFlush!: Unleash['destroyWithFlush'];
+
+  on!: Unleash['on'];
+
+  start!: Unleash['start'];
+
+  destroy!: Unleash['destroy'];
+
+  isSynchronized!: Unleash['isSynchronized'];
 }

--- a/src/metric-client.ts
+++ b/src/metric-client.ts
@@ -1,6 +1,10 @@
 import { Unleash } from './unleash';
 
-function forwardMethods<T extends object>(target: T, source: T, methodNames: (keyof T)[]) {
+function forwardMethods<T extends object>(
+  target: UnleashMetricClient,
+  source: Unleash,
+  methodNames: (keyof T)[],
+) {
   for (const name of methodNames) {
     // @ts-ignore
     target[name] = (...args: any[]) => source[name](...args);
@@ -12,7 +16,7 @@ export class UnleashMetricClient {
 
   constructor(unleash: Unleash) {
     this.backingInstance = unleash;
-    forwardMethods(this, this.backingInstance as any, [
+    forwardMethods(this, this.backingInstance, [
       'isEnabled',
       'getVariant',
       'forceGetVariant',


### PR DESCRIPTION
This is just a way to wrap the client in a decorator so we can limit exposure of the public API while we experiment on main. This could have been inheritance with less code, just feel this has better separation

Simple usage example moves from this:
``` node
const unleash = initialize({
  appName: 'my-application',
  url,
});
```
to this

``` node
const unleash = new UnleashMetricClient(initialize({
  appName: 'my-application',
  url,
}));

```