### PR TITLE
fix: also reduce back off counter for 304

### DIFF
--- a/src/repository/polling-fetcher.ts
+++ b/src/repository/polling-fetcher.ts
@@ -147,6 +147,7 @@ export class PollingFetcher extends EventEmitter implements FetcherInterface {
       });
       if (res.status === 304) {
         this.emit(UnleashEvents.Unchanged);
+        nextFetch = this.countSuccess();
       } else if (res.ok) {
         nextFetch = this.countSuccess();
         try {


### PR DESCRIPTION
304 responses are successful (server indicates cache is valid) but weren't calling `countSuccess()` to reduce the failure counter. This fix ensures both 304 and 200 responses contribute to backoff recovery, preventing the failure counter from remaining elevated during periods of unchanged flags.