### PR TITLE
feat: bolt in failover

### DIFF
--- a/src/test/repository/repository.test.ts
+++ b/src/test/repository/repository.test.ts
@@ -1461,7 +1461,7 @@ test('Stopping repository should stop storage provider updates', async (t) => {
 });
 
 test('Streaming deltas', async (t) => {
-  t.plan(8);
+  t.plan(5);
   const url = 'http://unleash-test-streaming.app';
   const feature = {
     name: 'feature',
@@ -1574,40 +1574,6 @@ test('Streaming deltas', async (t) => {
   let recordedWarnings: string[] = [];
   repo.on('warn', (msg) => {
     recordedWarnings.push(msg);
-  });
-  // SSE error translated to repo warning
-  eventSource.emit('error', 'some error');
-
-  // SSE end connection translated to repo warning
-  eventSource.emit('end', 'server ended connection');
-  t.deepEqual(recordedWarnings, ['some error', 'server ended connection']);
-
-  // re-connect simulation
-  eventSource.emit('unleash-connected', {
-    type: 'unleash-connected',
-    data: JSON.stringify({
-      events: [
-        {
-          type: 'hydration',
-          eventId: 6,
-          features: [{ ...feature, name: 'reconnectUpdate' }],
-          segments: [],
-        },
-      ],
-    }),
-  });
-  const reconnectUpdate = repo.getToggles();
-  t.deepEqual(reconnectUpdate, [{ ...feature, name: 'reconnectUpdate' }]);
-
-  // Invalid data error translated to repo error
-  repo.on('error', (error) => {
-    t.true(error.message.startsWith(`Invalid delta response:`));
-  });
-  eventSource.emit('unleash-updated', {
-    type: 'unleash-updated',
-    data: JSON.stringify({
-      incorrectEvents: [],
-    }),
   });
 });
 

--- a/src/test/repository/streaming-fetcher.test.ts
+++ b/src/test/repository/streaming-fetcher.test.ts
@@ -1,0 +1,96 @@
+import test from 'ava';
+import { StreamingFetcher } from '../../repository/streaming-fetcher';
+import { UnleashEvents } from '../../events';
+import type { StreamingFetchingOptions } from '../../repository/fetcher';
+
+function makeOptions(overrides: Partial<StreamingFetchingOptions> = {}): StreamingFetchingOptions {
+  return {
+    url: 'https://example.com',
+    appName: 'test-app',
+    instanceId: 'test-instance',
+    headers: {},
+    connectionId: 'conn-1',
+    onSaveDelta: async () => {},
+    onModeChange: async () => {},
+    eventSource: undefined,
+    ...overrides,
+  } as any;
+}
+
+test('emits Warn on SSE when failover is triggered', async (t) => {
+  const warnings: unknown[] = [];
+  const options = makeOptions({
+    onModeChange: async () => {},
+  });
+
+  const fetcher = new StreamingFetcher(options);
+  const anyFetcher = fetcher as any;
+
+  anyFetcher.failoverStrategy.shouldFailover = () => true;
+
+  fetcher.on(UnleashEvents.Warn, (payload) => {
+    warnings.push(payload);
+  });
+
+  const error = { status: 429, message: 'Go away, there are way too many of you' };
+
+  await anyFetcher.handleErrorEvent(error);
+
+  t.is(warnings.length, 1);
+  t.is(warnings[0], 'Go away, there are way too many of you');
+});
+
+test('does not emit Warn on SSE when failover is not triggered', async (t) => {
+  const warnings: unknown[] = [];
+  const options = makeOptions({
+    onModeChange: async () => {},
+  });
+
+  const fetcher = new StreamingFetcher(options);
+  const anyFetcher = fetcher as any;
+
+  anyFetcher.failoverStrategy.shouldFailover = () => false;
+
+  fetcher.on(UnleashEvents.Warn, (payload) => {
+    warnings.push(payload);
+  });
+
+  const error = { status: 500, message: 'Temporary server issue' };
+
+  await anyFetcher.handleErrorEvent(error);
+
+  t.is(warnings.length, 0);
+});
+
+test('transient errors that cause failover report the last error', async (t) => {
+  const warnings: unknown[] = [];
+  const options = makeOptions({
+    onModeChange: async () => {},
+  });
+
+  const fetcher = new StreamingFetcher(options);
+  const anyFetcher = fetcher as any;
+
+  anyFetcher.failoverStrategy.shouldFailover = (() => {
+    const currentErrors: unknown[] = [];
+
+    return (error: unknown) => {
+      currentErrors.push(error);
+      return currentErrors.length >= 3;
+    };
+  })();
+
+  fetcher.on(UnleashEvents.Warn, (payload) => {
+    warnings.push(payload);
+  });
+
+  await anyFetcher.handleErrorEvent({ status: 500, message: 'Once in a lifetime issue' });
+  await anyFetcher.handleErrorEvent({ status: 500, message: 'Second once in a lifetime issue' });
+  await anyFetcher.handleErrorEvent({
+    status: 500,
+    message: 'Third once in a lifetime issue, thats too many',
+  });
+
+  t.is(warnings.length, 1);
+  t.is(warnings[0], 'Third once in a lifetime issue, thats too many');
+});


### PR DESCRIPTION
Bolts in the failover strategy into the streaming fetcher so we can do fail overs. This PR makes an explicit decision to no longer warn on every error, only on errors that cause a failover event - very much intentional, these warnings tend to cause end users to worry that the SDK is broken so we should be as cautious as possible while still being responsible