### PR TITLE
chore: expose config for failover

### DIFF
--- a/src/repository/fetcher.ts
+++ b/src/repository/fetcher.ts
@@ -34,4 +34,6 @@ export interface PollingFetchingOptions extends CommonFetchingOptions {
 
 export interface StreamingFetchingOptions extends CommonFetchingOptions {
   eventSource?: EventSource;
+  maxFailuresUntilFailover?: number;
+  failureWindowMs?: number;
 }


### PR DESCRIPTION
Exposes the fail over config options. I've moved de-structured the options here into class level variables. Personal opinion but delegating to options get a bit messy when trying to setup derived fields and defaults. Open to reverting that if someone can give me something that doesn't look like a rat's nest