### PR TITLE
chore!: drop node 16 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "semver": "^7.6.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Node 16 is already end of life, removing this will allow us to unpin some dependencies.

<img width="689" height="260" alt="image" src="https://github.com/user-attachments/assets/c24bc169-fed5-4878-95f7-ecbacc19a244" />
