### PR TITLE
chore: avoid having tar in resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "json5": "^2.0.0",
     "qs": "^6.5.3",
     "minimatch": "^9.0.0",
-    "semver": "^7.5.3",
-    "tar": "^7.5.3"
+    "semver": "^7.5.3"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx,json,md}": [


### PR DESCRIPTION
Now we just rely on the transitive dependency