### PR TITLE
docs: fix tag filter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ The initialize method takes the following arguments:
   options as they may compromise your application security.
 - **namePrefix** - Only fetch feature toggles with the provided name prefix.
 - **tags** - Only fetch feature toggles tagged with the list of tags, such as:
-  `[{type: 'simple', value: 'proxy'}]`.
+  `[{name: 'simple', value: 'proxy'}]`.
 
 ## Custom strategies
 


### PR DESCRIPTION
Example doesn't work. Our code actually uses the "name" property: https://github.com/Unleash/unleash-node-sdk/blob/ce031d4427dcfa2f37188df9fbc67b896877d5b6/src/repository/polling-fetcher.ts#L189