### PR TITLE
fix: not initialized yet warnings

### DIFF
--- a/src/test/unleash.test.ts
+++ b/src/test/unleash.test.ts
@@ -568,9 +568,7 @@ test('should distribute variants according to stickiness', async () => {
   await new Promise<void>((resolve) => {
     unleash.on('synchronized', () => {
       for (let i = 0; i < 10000; i++) {
-        const variant = unleash.getVariant('toggle-with-variants', {
-          someField: genRandomValue(),
-        });
+        const variant = unleash.getVariant('toggle-with-variants', { someField: genRandomValue() });
         // @ts-expect-error
         counts[variant.name]++;
         counts.sum++;
@@ -644,9 +642,7 @@ test('should distribute variants according to default stickiness', async () => {
   await new Promise<void>((resolve) => {
     unleash.on('synchronized', () => {
       for (let i = 0; i < 10000; i++) {
-        const variant = unleash.getVariant('toggle-with-variants', {
-          userId: genRandomValue(),
-        });
+        const variant = unleash.getVariant('toggle-with-variants', { userId: genRandomValue() });
         // @ts-expect-error
         counts[variant.name]++;
         counts.sum++;
@@ -944,11 +940,7 @@ test('should allow custom repository', async () => {
       storageProvider: new InMemStorageProvider(),
       repository: {
         // @ts-expect-error
-        getToggle: () => ({
-          name: 'test',
-          enabled: true,
-          strategies: [{ name: 'default' }],
-        }),
+        getToggle: () => ({ name: 'test', enabled: true, strategies: [{ name: 'default' }] }),
         getToggles: () => [],
         getSegment: () => undefined,
         stop: () => {},
@@ -1002,12 +994,7 @@ test('should report variant metrics', async () => {
     name: 'toggle-with-variants',
     enabled: true,
     strategies: [{ name: 'default', constraints: [] }],
-    variants: [
-      {
-        name: 'toggle-variant',
-        payload: { type: 'string', value: 'variant value' },
-      },
-    ],
+    variants: [{ name: 'toggle-variant', payload: { type: 'string', value: 'variant value' } }],
   });
 
   instance.getVariant('toggle-with-variants');
@@ -1068,12 +1055,7 @@ test('should not report dependent feature metrics', async () => {
     enabled: true,
     dependencies: [{ feature: 'dependency' }],
     strategies: [{ name: 'default', constraints: [] }],
-    variants: [
-      {
-        name: 'toggle-variant',
-        payload: { type: 'string', value: 'variant value' },
-      },
-    ],
+    variants: [{ name: 'toggle-variant', payload: { type: 'string', value: 'variant value' } }],
   });
 
   instance.getVariant('toggle-with-dependency');

--- a/src/test/unleash.test.ts
+++ b/src/test/unleash.test.ts
@@ -1077,6 +1077,73 @@ test('should not report dependent feature metrics', async () => {
   });
 });
 
+test('should emit correctly serialized warn for getVariant before initialized', () => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    skipInstanceCountWarning: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  });
+
+  const warnings: string[] = [];
+  instance.on('warn', (msg) => warnings.push(msg));
+
+  instance.getVariant('my-feature');
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('getVariant(my-feature)');
+  expect(warnings[0]).not.toContain('[object Object]');
+  expect(warnings[0]).toContain('"name":"disabled"');
+
+  instance.destroy();
+});
+
+test('should emit correctly serialized warn for getVariant with custom fallback before initialized', () => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    skipInstanceCountWarning: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  });
+
+  const warnings: string[] = [];
+  instance.on('warn', (msg) => warnings.push(msg));
+
+  const fallback = { name: 'custom', enabled: true, feature_enabled: true };
+  instance.getVariant('my-feature', {}, fallback);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('getVariant(my-feature)');
+  expect(warnings[0]).not.toContain('[object Object]');
+  expect(warnings[0]).toContain('"name":"custom"');
+
+  instance.destroy();
+});
+
+test('should emit correctly serialized warn for forceGetVariant before initialized', () => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    skipInstanceCountWarning: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  });
+
+  const warnings: string[] = [];
+  instance.on('warn', (msg) => warnings.push(msg));
+
+  instance.forceGetVariant('my-feature');
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('forceGetVariant(my-feature)');
+  expect(warnings[0]).not.toContain('[object Object]');
+  expect(warnings[0]).toContain('"name":"disabled"');
+
+  instance.destroy();
+});
+
 test('should not allow to start twice', async () => {
   const url = mockNetwork();
   let repositoryStartedCount = 0;

--- a/src/test/unleash.test.ts
+++ b/src/test/unleash.test.ts
@@ -568,7 +568,9 @@ test('should distribute variants according to stickiness', async () => {
   await new Promise<void>((resolve) => {
     unleash.on('synchronized', () => {
       for (let i = 0; i < 10000; i++) {
-        const variant = unleash.getVariant('toggle-with-variants', { someField: genRandomValue() });
+        const variant = unleash.getVariant('toggle-with-variants', {
+          someField: genRandomValue(),
+        });
         // @ts-expect-error
         counts[variant.name]++;
         counts.sum++;
@@ -642,7 +644,9 @@ test('should distribute variants according to default stickiness', async () => {
   await new Promise<void>((resolve) => {
     unleash.on('synchronized', () => {
       for (let i = 0; i < 10000; i++) {
-        const variant = unleash.getVariant('toggle-with-variants', { userId: genRandomValue() });
+        const variant = unleash.getVariant('toggle-with-variants', {
+          userId: genRandomValue(),
+        });
         // @ts-expect-error
         counts[variant.name]++;
         counts.sum++;
@@ -940,7 +944,11 @@ test('should allow custom repository', async () => {
       storageProvider: new InMemStorageProvider(),
       repository: {
         // @ts-expect-error
-        getToggle: () => ({ name: 'test', enabled: true, strategies: [{ name: 'default' }] }),
+        getToggle: () => ({
+          name: 'test',
+          enabled: true,
+          strategies: [{ name: 'default' }],
+        }),
         getToggles: () => [],
         getSegment: () => undefined,
         stop: () => {},
@@ -994,7 +1002,12 @@ test('should report variant metrics', async () => {
     name: 'toggle-with-variants',
     enabled: true,
     strategies: [{ name: 'default', constraints: [] }],
-    variants: [{ name: 'toggle-variant', payload: { type: 'string', value: 'variant value' } }],
+    variants: [
+      {
+        name: 'toggle-variant',
+        payload: { type: 'string', value: 'variant value' },
+      },
+    ],
   });
 
   instance.getVariant('toggle-with-variants');
@@ -1055,7 +1068,12 @@ test('should not report dependent feature metrics', async () => {
     enabled: true,
     dependencies: [{ feature: 'dependency' }],
     strategies: [{ name: 'default', constraints: [] }],
-    variants: [{ name: 'toggle-variant', payload: { type: 'string', value: 'variant value' } }],
+    variants: [
+      {
+        name: 'toggle-variant',
+        payload: { type: 'string', value: 'variant value' },
+      },
+    ],
   });
 
   instance.getVariant('toggle-with-dependency');
@@ -1116,29 +1134,6 @@ test('should emit correctly serialized warn for getVariant before initialized', 
   expect(warnings[0]).toContain("getVariant('my-feature')");
   expect(warnings[0]).not.toContain('[object Object]');
   expect(warnings[0]).toContain('"name":"disabled"');
-
-  instance.destroy();
-});
-
-test('should emit correctly serialized warn for getVariant with custom fallback before initialized', () => {
-  const url = mockNetwork();
-  const instance = new Unleash({
-    appName: 'foo',
-    disableMetrics: true,
-    skipInstanceCountWarning: true,
-    url,
-    backupPath: getRandomBackupPath(),
-  });
-
-  const warnings: string[] = [];
-  instance.on('warn', (msg) => warnings.push(msg));
-
-  const fallback = { name: 'custom', enabled: true, feature_enabled: true };
-  instance.getVariant('my-feature', {}, fallback);
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0]).toContain("getVariant('my-feature')");
-  expect(warnings[0]).not.toContain('[object Object]');
-  expect(warnings[0]).toContain('"name":"custom"');
 
   instance.destroy();
 });

--- a/src/test/unleash.test.ts
+++ b/src/test/unleash.test.ts
@@ -1077,6 +1077,27 @@ test('should not report dependent feature metrics', async () => {
   });
 });
 
+test('should emit correctly formatted warn for isEnabled before initialized', () => {
+  const url = mockNetwork();
+  const instance = new Unleash({
+    appName: 'foo',
+    disableMetrics: true,
+    skipInstanceCountWarning: true,
+    url,
+    backupPath: getRandomBackupPath(),
+  });
+
+  const warnings: string[] = [];
+  instance.on('warn', (msg) => warnings.push(msg));
+
+  expect(instance.isEnabled('my-feature')).toBe(false);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain("isEnabled('my-feature')");
+  expect(warnings[0]).toContain('false');
+
+  instance.destroy();
+});
+
 test('should emit correctly serialized warn for getVariant before initialized', () => {
   const url = mockNetwork();
   const instance = new Unleash({
@@ -1092,7 +1113,7 @@ test('should emit correctly serialized warn for getVariant before initialized', 
 
   instance.getVariant('my-feature');
   expect(warnings).toHaveLength(1);
-  expect(warnings[0]).toContain('getVariant(my-feature)');
+  expect(warnings[0]).toContain("getVariant('my-feature')");
   expect(warnings[0]).not.toContain('[object Object]');
   expect(warnings[0]).toContain('"name":"disabled"');
 
@@ -1115,7 +1136,7 @@ test('should emit correctly serialized warn for getVariant with custom fallback 
   const fallback = { name: 'custom', enabled: true, feature_enabled: true };
   instance.getVariant('my-feature', {}, fallback);
   expect(warnings).toHaveLength(1);
-  expect(warnings[0]).toContain('getVariant(my-feature)');
+  expect(warnings[0]).toContain("getVariant('my-feature')");
   expect(warnings[0]).not.toContain('[object Object]');
   expect(warnings[0]).toContain('"name":"custom"');
 
@@ -1137,7 +1158,7 @@ test('should emit correctly serialized warn for forceGetVariant before initializ
 
   instance.forceGetVariant('my-feature');
   expect(warnings).toHaveLength(1);
-  expect(warnings[0]).toContain('forceGetVariant(my-feature)');
+  expect(warnings[0]).toContain("forceGetVariant('my-feature')");
   expect(warnings[0]).not.toContain('[object Object]');
   expect(warnings[0]).toContain('"name":"disabled"');
 

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -291,7 +291,7 @@ export class Unleash extends EventEmitter {
       result = fallbackFunc();
       this.emit(
         UnleashEvents.Warn,
-        `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${result}`,
+        `Unleash has not been initialized yet. isEnabled('${name}') defaulted to ${result}`,
       );
     }
     this.count(name, result);
@@ -314,7 +314,7 @@ export class Unleash extends EventEmitter {
           : { ...defaultVariant, featureEnabled: defaultVariant.feature_enabled ?? false };
       this.emit(
         UnleashEvents.Warn,
-        `Unleash has not been initialized yet. getVariant(${name}) defaulted to ${JSON.stringify(variant)}`,
+        `Unleash has not been initialized yet. getVariant('${name}') defaulted to ${JSON.stringify(variant)}`,
       );
     }
 
@@ -339,7 +339,7 @@ export class Unleash extends EventEmitter {
           : defaultVariant;
       this.emit(
         UnleashEvents.Warn,
-        `Unleash has not been initialized yet. forceGetVariant(${name}) defaulted to ${JSON.stringify(variant)}`,
+        `Unleash has not been initialized yet. forceGetVariant('${name}') defaulted to ${JSON.stringify(variant)}`,
       );
     }
     if (variant.name) {

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -314,7 +314,7 @@ export class Unleash extends EventEmitter {
           : { ...defaultVariant, featureEnabled: defaultVariant.feature_enabled ?? false };
       this.emit(
         UnleashEvents.Warn,
-        `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${variant}`,
+        `Unleash has not been initialized yet. getVariant(${name}) defaulted to ${JSON.stringify(variant)}`,
       );
     }
 
@@ -339,7 +339,7 @@ export class Unleash extends EventEmitter {
           : defaultVariant;
       this.emit(
         UnleashEvents.Warn,
-        `Unleash has not been initialized yet. isEnabled(${name}) defaulted to ${variant}`,
+        `Unleash has not been initialized yet. forceGetVariant(${name}) defaulted to ${JSON.stringify(variant)}`,
       );
     }
     if (variant.name) {


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-564/fix-not-initialized-yet-warnings-in-the-node-sdk

Fixes "not initialized yet" warnings being emitted in the `getVariant` and `forceGetVariant` methods.