### PR TITLE
chore: fix deprecation notes on MetricsAPI methods via overloads

### DIFF
--- a/src/impact-metrics/metric-api.ts
+++ b/src/impact-metrics/metric-api.ts
@@ -58,8 +58,11 @@ export class MetricsAPI extends EventEmitter {
   }
 
   /**
-   * @param flagContext - @deprecated This parameter will be removed in a future release.
+   * @deprecated The flagContext parameter will be removed in a future release.
+   *             Call without flagContext.
    */
+  incrementCounter(name: string, value: number | undefined, flagContext: MetricFlagContext): void;
+  incrementCounter(name: string, value?: number): void;
   incrementCounter(name: string, value?: number, flagContext?: MetricFlagContext): void {
     const counter = this.metricRegistry.getCounter(name);
     if (!counter) {
@@ -81,8 +84,11 @@ export class MetricsAPI extends EventEmitter {
   }
 
   /**
-   * @param flagContext - @deprecated This parameter will be removed in a future release.
+   * @deprecated The flagContext parameter will be removed in a future release.
+   *             Call without flagContext.
    */
+  updateGauge(name: string, value: number, flagContext: MetricFlagContext): void;
+  updateGauge(name: string, value: number): void;
   updateGauge(name: string, value: number, flagContext?: MetricFlagContext): void {
     const gauge = this.metricRegistry.getGauge(name);
     if (!gauge) {
@@ -101,8 +107,11 @@ export class MetricsAPI extends EventEmitter {
   }
 
   /**
-   * @param flagContext - @deprecated This parameter will be removed in a future release.
+   * @deprecated The flagContext parameter will be removed in a future release.
+   *             Call without flagContext.
    */
+  observeHistogram(name: string, value: number, flagContext: MetricFlagContext): void;
+  observeHistogram(name: string, value: number): void;
   observeHistogram(name: string, value: number, flagContext?: MetricFlagContext): void {
     const histogram = this.metricRegistry.getHistogram(name);
     if (!histogram) {

--- a/src/test/impact-metrics/metric-client.test.ts
+++ b/src/test/impact-metrics/metric-client.test.ts
@@ -91,13 +91,11 @@ test('should register a gauge with valid name and help', () => {
 });
 
 test('should increment counter with valid parameters', () => {
-  let counterIncremented = false;
-  let recordedLabels: MetricLabels = {};
+  const calls: MetricLabels[] = [];
 
   const fakeCounter = {
     inc: (_value: number, labels: MetricLabels) => {
-      counterIncremented = true;
-      recordedLabels = labels;
+      calls.push(labels);
     },
   };
 
@@ -109,12 +107,12 @@ test('should increment counter with valid parameters', () => {
   const api = new MetricsAPI(fakeRegistry, fakeVariantResolver(), staticContext);
 
   api.incrementCounter('valid_counter', 5);
-  expect(counterIncremented, 'Counter should be incremented with valid parameters').toBe(true);
-  expect(recordedLabels).toStrictEqual({
-    appName: 'my-app',
-    environment: 'dev',
-    featureX: 'enabled',
-  });
+  api.incrementCounter('valid_counter', 5, { flagNames: ['featureX'], context: staticContext });
+
+  expect(calls).toStrictEqual([
+    { appName: 'my-app', environment: 'dev' },
+    { appName: 'my-app', environment: 'dev', featureX: 'enabled' },
+  ]);
 });
 
 test('should set gauge with valid parameters', () => {

--- a/src/test/impact-metrics/metric-client.test.ts
+++ b/src/test/impact-metrics/metric-client.test.ts
@@ -108,7 +108,7 @@ test('should increment counter with valid parameters', () => {
   const staticContext = { appName: 'my-app', environment: 'dev' };
   const api = new MetricsAPI(fakeRegistry, fakeVariantResolver(), staticContext);
 
-  api.incrementCounter('valid_counter', 5, { flagNames: ['featureX'], context: staticContext });
+  api.incrementCounter('valid_counter', 5);
   expect(counterIncremented, 'Counter should be incremented with valid parameters').toBe(true);
   expect(recordedLabels).toStrictEqual({
     appName: 'my-app',


### PR DESCRIPTION
The `@deprecated` JSDoc on `incrementCounter`, `updateGauge`, and `observeHistogram` was attached to the `flagContext` parameter, but with only a single implementation signature TypeScript/IDEs applied the deprecation to the entire method. Every call — including supported ones that omit `flagContext` — was being shown as deprecated.

This change splits each method into two overload signatures:
- A `@deprecated` overload that requires `flagContext` (the one we want to discourage).
- A non-deprecated overload without `flagContext` (the supported usage).

The implementation signature is unchanged. Now only calls that actually pass `flagContext` get the deprecation warning; calls without it resolve to the non-deprecated overload.

The `should increment counter with valid parameters` test now exercises both overloads — one call without `flagContext` (non-deprecated) and one with (deprecated) — and asserts the labels produced by each.

<img width="894" height="116" alt="image" src="https://github.com/user-attachments/assets/e798a324-44b5-4cff-a2a2-53db012c622f" />
