### PR TITLE
feat: add SDK flavor and version in register & metrics payload

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -395,6 +395,8 @@ export default class Metrics extends EventEmitter {
       platformVersion: this.platformData.version,
       yggdrasilVersion: null,
       specVersion: SUPPORTED_SPEC_VERSION,
+      sdkFlavor: this.sdkFlavor,
+      sdkFlavorVersion: this.sdkFlavorVersion,
     };
 
     if (impactMetrics.length > 0) {
@@ -435,6 +437,8 @@ export default class Metrics extends EventEmitter {
       platformVersion: this.platformData.version,
       yggdrasilVersion: null,
       specVersion: SUPPORTED_SPEC_VERSION,
+      sdkFlavor: this.sdkFlavor,
+      sdkFlavorVersion: this.sdkFlavorVersion,
     };
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -23,6 +23,8 @@ export interface MetricsOptions {
   timeout?: number;
   httpOptions?: HttpOptions;
   metricRegistry?: ImpactMetricsDataSource;
+  sdkFlavor?: string;
+  sdkFlavorVersion?: string;
 }
 
 interface VariantBucket {
@@ -64,6 +66,8 @@ interface BaseMetricsData {
   platformVersion: string;
   yggdrasilVersion: null;
   specVersion: string;
+  sdkFlavor?: string;
+  sdkFlavorVersion?: string;
 }
 
 interface MetricsData extends BaseMetricsData {
@@ -117,6 +121,10 @@ export default class Metrics extends EventEmitter {
 
   private metricRegistry?: ImpactMetricsDataSource;
 
+  private sdkFlavor?: string;
+
+  private sdkFlavorVersion?: string;
+
   constructor({
     appName,
     instanceId,
@@ -131,6 +139,8 @@ export default class Metrics extends EventEmitter {
     timeout,
     httpOptions,
     metricRegistry,
+    sdkFlavor,
+    sdkFlavorVersion,
   }: MetricsOptions) {
     super();
     this.disabled = disableMetrics;
@@ -150,6 +160,8 @@ export default class Metrics extends EventEmitter {
     this.httpOptions = httpOptions;
     this.platformData = this.getPlatformData();
     this.metricRegistry = metricRegistry;
+    this.sdkFlavor = sdkFlavor;
+    this.sdkFlavorVersion = sdkFlavorVersion;
   }
 
   private getAppliedJitter(): number {

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -180,6 +180,71 @@ test('should send content-type header', async () => {
   metrics.stop();
 });
 
+test('sdkFlavor exists in the register and metrics request bodies', async () => {
+  const url = getUrl();
+  expect.assertions(2);
+
+  const regEP = nock(url)
+    .post(
+      registerUrl,
+      (body) =>
+        body.sdkFlavor === 'unleash-openfeature-node-provider' &&
+        body.sdkFlavorVersion === '1.2.3' &&
+        body.sdkVersion !== body.sdkFlavorVersion, // the SDK version is still there
+    )
+    .reply(200, '');
+
+  const metricsEP = nock(url)
+    .post(
+      metricsUrl,
+      (body) =>
+        body.sdkFlavor === 'unleash-openfeature-node-provider' && body.sdkFlavorVersion === '1.2.3',
+    )
+    .reply(200, '');
+
+  // @ts-expect-error partial options for test
+  const metrics = new Metrics({
+    url,
+    metricsInterval: 50,
+    sdkFlavor: 'unleash-openfeature-node-provider',
+    sdkFlavorVersion: '1.2.3',
+  });
+
+  metrics.count('toggle-x', true);
+  await metrics.registerInstance();
+  await metrics.sendMetrics();
+
+  expect(regEP.isDone()).toBe(true);
+  expect(metricsEP.isDone()).toBe(true);
+  metrics.stop();
+});
+
+test('sdkFlavor is absent from request bodies when not configured', async () => {
+  const url = getUrl();
+  expect.assertions(2);
+
+  const regEP = nock(url)
+    .post(registerUrl, (body) => !('sdkFlavor' in body) && !('sdkFlavorVersion' in body))
+    .reply(200, '');
+  const metricsEP = nock(url)
+    .post(metricsUrl, (body) => !('sdkFlavor' in body) && !('sdkFlavorVersion' in body))
+    .reply(200, '');
+
+  // @ts-expect-error partial options for test
+  const metrics = new Metrics({
+    url,
+    metricsInterval: 50,
+  });
+
+  metrics.count('toggle-x', true);
+  await metrics.registerInstance();
+  await metrics.sendMetrics();
+
+  expect(regEP.isDone()).toBe(true);
+  expect(metricsEP.isDone()).toBe(true);
+  metrics.stop();
+});
+
 test('request with customHeadersFunction should take precedence over customHeaders', async () => {
   const url = getUrl();
   expect.assertions(2);

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -411,6 +411,49 @@ test('getMetricsData should return a bucket', () => {
   expect(typeof result.bucket === 'object').toBe(true);
 });
 
+test('sdkFlavor exists in both register and metrics payloads when set', () => {
+  const url = getUrl();
+  // @ts-expect-error partial options for test
+  const metrics = new Metrics({
+    url,
+    sdkFlavor: 'unleash-openfeature-node-provider',
+    sdkFlavorVersion: '1.2.3',
+  });
+  metrics.start();
+
+  const registration = metrics.getClientData();
+
+  expect(registration.sdkFlavor).toBe('unleash-openfeature-node-provider');
+  expect(registration.sdkFlavorVersion).toBe('1.2.3');
+  expect(registration.sdkVersion).not.toBe(registration.sdkFlavorVersion); // sdk version never replaced!
+
+  const metricsData = metrics.createMetricsData([]);
+
+  expect(metricsData.sdkFlavor).toBe('unleash-openfeature-node-provider');
+  expect(metricsData.sdkFlavorVersion).toBe('1.2.3');
+});
+
+test('sdkFlavor is omitted from payloads when unset', () => {
+  const url = getUrl();
+  // @ts-expect-error partial options for test
+  const metrics = new Metrics({
+    url,
+  });
+  metrics.start();
+
+  const registration = metrics.getClientData();
+
+  expect(registration.sdkFlavor).toBeUndefined();
+  expect(registration.sdkFlavorVersion).toBeUndefined();
+  expect(JSON.parse(JSON.stringify(registration))).not.toHaveProperty('sdkFlavor');
+  expect(JSON.parse(JSON.stringify(registration))).not.toHaveProperty('sdkFlavorVersion');
+
+  const metricsData = metrics.createMetricsData([]);
+
+  expect(JSON.parse(JSON.stringify(metricsData))).not.toHaveProperty('sdkFlavor');
+  expect(JSON.parse(JSON.stringify(metricsData))).not.toHaveProperty('sdkFlavorVersion');
+});
+
 test('should keep metrics if send is failing', async () => {
   await new Promise<void>((resolve) => {
     const url = getUrl();

--- a/src/unleash-config.ts
+++ b/src/unleash-config.ts
@@ -34,4 +34,6 @@ export interface UnleashConfig {
   disableAutoStart?: boolean;
   skipInstanceCountWarning?: boolean;
   experimentalMode?: Mode;
+  sdkFlavor?: string;
+  sdkFlavorVersion?: string;
 }

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -81,6 +81,8 @@ export class Unleash extends EventEmitter {
     disableAutoStart = false,
     skipInstanceCountWarning = false,
     experimentalMode = { type: 'polling', format: 'full' },
+    sdkFlavor,
+    sdkFlavorVersion,
   }: UnleashConfig) {
     super();
 
@@ -186,6 +188,8 @@ export class Unleash extends EventEmitter {
       timeout,
       httpOptions,
       metricRegistry: this.metricRegistry,
+      sdkFlavor,
+      sdkFlavorVersion,
     });
 
     this.impactMetrics = new MetricsAPI(


### PR DESCRIPTION
Right now we can see which SDK and version a client is running, but not what's built on top of it. When someone uses our OpenFeature provider (_or any other integration_) it just looks like a plain Node SDK: we can't tell how much of our usage flows through those integrations, or which versions are running.

This [PR on node-provider](https://github.com/Unleash/unleash-openfeature-node-provider/pull/23) adds the optional `sdkFlavor`, `sdkFlavorVersion` to the Unleash config.
And here we update the SDK config and forwards them in the two payloads we already send: POST /client/register and POST /client/metrics. It goes alongside `sdkVersion` - so we keep the underlying SDK version and gain the integration identity on top.

### What changed
- `UnleashConfig` accepts `sdkFlavor` and `sdkFlavorVersion`
- Unleash passes them through to `Metrics`
- Metrics includes them in `getClientData()` (register) and `createMetricsData() `(metrics). Both are optional and drop out of the JSON body when unset, so nothing changes if you don't set them.

### Testing
- Added Unit tests to cover set and unset scenarios
- Added nock tests to assert the fields actually appear in the register and metrics request bodies and are absent when not configured.