### PR TITLE
chore: update npm-release workflow version to v3.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   from-template:
-    uses: Unleash/.github/.github/workflows/npm-release.yml@v3.0.1
+    uses: Unleash/.github/.github/workflows/npm-release.yml@v3.0.2
     with:
       version: ${{ github.event.inputs.version }}
       tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
This pins the pnpm version to one compatible with node 20 which we still support
